### PR TITLE
refactor: simplify Phase 1A — shared SSE, deque, timeout fix

### DIFF
--- a/app/frontend/src/display/Slideshow.jsx
+++ b/app/frontend/src/display/Slideshow.jsx
@@ -11,6 +11,7 @@
  */
 import { signal } from "@preact/signals";
 import { useRef, useEffect, useCallback } from "preact/hooks";
+import { createSSE } from "../lib/sse.js";
 
 // --- Signals (module-level for SSE reactivity) ---
 const photoList = signal([]);
@@ -92,7 +93,10 @@ function transitionMs(type) {
 /** Remove all child nodes from a DOM element (safe alternative to innerHTML). */
 function clearChildren(el) {
   while (el.firstChild) {
-    el.removeChild(el.firstChild);
+    const child = el.firstChild;
+    // Clear any pending error timeout before removing (prevents leak)
+    if (child._errTimeout) clearTimeout(child._errTimeout);
+    el.removeChild(child);
   }
 }
 
@@ -100,7 +104,7 @@ function clearChildren(el) {
  * Set the source of a layer element (img or video).
  * Replaces the element's children to switch between img/video cleanly.
  */
-function setLayerContent(layer, photo, onVideoEnded) {
+function setLayerContent(layer, photo, onAdvance) {
   if (!layer || !photo) return;
   clearChildren(layer);
   if (photo.is_video) {
@@ -111,8 +115,8 @@ function setLayerContent(layer, photo, onVideoEnded) {
     vid.playsInline = true;
     vid.style.cssText =
       "position:absolute;inset:0;width:100%;height:100%;object-fit:contain;";
-    if (onVideoEnded) {
-      vid.addEventListener("ended", onVideoEnded, { once: true });
+    if (onAdvance) {
+      vid.addEventListener("ended", onAdvance, { once: true });
     }
     layer.appendChild(vid);
   } else {
@@ -123,9 +127,9 @@ function setLayerContent(layer, photo, onVideoEnded) {
       "position:absolute;inset:0;width:100%;height:100%;object-fit:contain;image-orientation:from-image;";
     img.onerror = () => {
       console.warn("Slideshow: failed to load image", photo.name);
-      // Advance to next photo after 3s on broken image
-      if (onVideoEnded) {
-        setTimeout(onVideoEnded, 3000);
+      if (onAdvance) {
+        // Store timeout ID on the element for cleanup
+        img._errTimeout = setTimeout(onAdvance, 3000);
       }
     };
     layer.appendChild(img);
@@ -269,8 +273,6 @@ export function Slideshow() {
     init();
 
     // SSE: refresh list on photo:added / photo:deleted
-    let source = null;
-
     function handlePhotoChange() {
       if (cancelled) return;
       fetch("/api/photos")
@@ -289,42 +291,25 @@ export function Slideshow() {
         .catch((err) => console.error("Slideshow: SSE refetch failed", err));
     }
 
-    let sseBackoff = 1000;
-    const SSE_BACKOFF_MAX = 60000;
-
-    function connectSSE() {
-      if (source) source.close();
-      source = new EventSource("/api/events");
-
-      source.addEventListener("photo:added", handlePhotoChange);
-      source.addEventListener("photo:deleted", handlePhotoChange);
-      source.addEventListener("settings:changed", (evt) => {
-        if (cancelled) return;
-        try {
-          const cfg = JSON.parse(evt.data);
-          settingsData.value = cfg;
-        } catch (parseErr) {
-          console.warn("Slideshow: failed to parse settings:changed SSE data", parseErr);
-        }
-      });
-
-      source.onopen = () => {
-        // Reset backoff on successful connection
-        sseBackoff = 1000;
-      };
-
-      source.onerror = () => {
-        source.close();
-        setTimeout(connectSSE, sseBackoff);
-        sseBackoff = Math.min(sseBackoff * 2, SSE_BACKOFF_MAX);
-      };
-    }
-
-    connectSSE();
+    const sse = createSSE("/api/events", {
+      listeners: {
+        "photo:added": handlePhotoChange,
+        "photo:deleted": handlePhotoChange,
+        "settings:changed": (evt) => {
+          if (cancelled) return;
+          try {
+            const cfg = JSON.parse(evt.data);
+            settingsData.value = cfg;
+          } catch (parseErr) {
+            console.warn("Slideshow: failed to parse settings:changed SSE data", parseErr);
+          }
+        },
+      },
+    });
 
     return () => {
       cancelled = true;
-      if (source) source.close();
+      sse.close();
       const s = state.current;
       if (s.timer) {
         clearTimeout(s.timer);

--- a/app/frontend/src/lib/sse.js
+++ b/app/frontend/src/lib/sse.js
@@ -1,0 +1,64 @@
+/**
+ * SSE connection helper with exponential backoff reconnection.
+ *
+ * Handles connect/reconnect/cleanup. Consumers provide named event
+ * listeners via the `listeners` map — these are re-attached on each
+ * reconnect so they survive connection drops.
+ *
+ * Usage:
+ *   const sse = createSSE("/api/events", {
+ *     listeners: {
+ *       "photo:added": (evt) => refresh(),
+ *       "settings:changed": (evt) => applySettings(JSON.parse(evt.data)),
+ *     },
+ *     onOpen: () => console.log("connected"),
+ *   });
+ *   // cleanup:
+ *   sse.close();
+ */
+
+const BACKOFF_INITIAL = 1000;
+const BACKOFF_MAX = 60000;
+
+export function createSSE(url, { listeners = {}, onOpen } = {}) {
+  let source = null;
+  let backoff = BACKOFF_INITIAL;
+  let reconnectTimer = null;
+  let closed = false;
+
+  function connect() {
+    if (closed) return;
+    if (source) source.close();
+
+    source = new EventSource(url);
+
+    // Attach named event listeners (survive reconnect)
+    for (const [event, handler] of Object.entries(listeners)) {
+      source.addEventListener(event, handler);
+    }
+
+    source.onopen = () => {
+      backoff = BACKOFF_INITIAL;
+      if (onOpen) onOpen();
+    };
+
+    source.onerror = () => {
+      source.close();
+      source = null;
+      if (!closed) {
+        reconnectTimer = setTimeout(connect, backoff);
+        backoff = Math.min(backoff * 2, BACKOFF_MAX);
+      }
+    };
+  }
+
+  function close() {
+    closed = true;
+    if (reconnectTimer) clearTimeout(reconnectTimer);
+    if (source) source.close();
+    source = null;
+  }
+
+  connect();
+  return { close };
+}

--- a/app/frontend/src/pages/Upload.jsx
+++ b/app/frontend/src/pages/Upload.jsx
@@ -3,6 +3,7 @@ import { signal } from "@preact/signals";
 import { useEffect, useRef } from "preact/hooks";
 import { ShDropzone } from "../components/ShDropzone.jsx";
 import { PhotoGrid } from "../components/PhotoGrid.jsx";
+import { createSSE } from "../lib/sse.js";
 
 /** Reactive state */
 const photos = signal([]);
@@ -48,41 +49,10 @@ function fetchStatus() {
  */
 export function Upload() {
   const sseRef = useRef(null);
-  const reconnectTimer = useRef(null);
-  const sseBackoff = useRef(1000);
-  const SSE_BACKOFF_MAX = 60000;
 
-  /** Connect to SSE endpoint with exponential backoff reconnect. */
-  function connectSSE() {
-    if (sseRef.current) {
-      sseRef.current.close();
-    }
-
-    const es = new EventSource("/api/events");
-    sseRef.current = es;
-
-    es.addEventListener("photo:added", () => {
-      fetchPhotos();
-      fetchStatus();
-    });
-
-    es.addEventListener("photo:deleted", () => {
-      fetchPhotos();
-      fetchStatus();
-    });
-
-    es.onopen = () => {
-      // Reset backoff on successful connection
-      sseBackoff.current = 1000;
-    };
-
-    es.onerror = () => {
-      es.close();
-      sseRef.current = null;
-      clearTimeout(reconnectTimer.current);
-      reconnectTimer.current = setTimeout(connectSSE, sseBackoff.current);
-      sseBackoff.current = Math.min(sseBackoff.current * 2, SSE_BACKOFF_MAX);
-    };
+  function handleRefresh() {
+    fetchPhotos();
+    fetchStatus();
   }
 
   useEffect(() => {
@@ -91,14 +61,16 @@ export function Upload() {
       loading.value = false;
     });
 
-    // Connect SSE
-    connectSSE();
+    // Connect SSE with shared backoff utility
+    const sse = createSSE("/api/events", {
+      listeners: {
+        "photo:added": handleRefresh,
+        "photo:deleted": handleRefresh,
+      },
+    });
+    sseRef.current = sse;
 
-    // Cleanup on unmount
-    return () => {
-      if (sseRef.current) sseRef.current.close();
-      clearTimeout(reconnectTimer.current);
-    };
+    return () => sse.close();
   }, []);
 
   function handleUpload() {

--- a/app/sse.py
+++ b/app/sse.py
@@ -9,6 +9,7 @@ import logging
 import os
 import threading
 import time
+from collections import deque
 from queue import Empty, Full, Queue
 
 log = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ _event_id_lock = threading.Lock()
 
 # Recent event buffer for reconnection (ring buffer of (id, event, data))
 _RECENT_BUFFER_SIZE = 50
-_recent_events = []
+_recent_events = deque(maxlen=_RECENT_BUFFER_SIZE)
 _recent_lock = threading.Lock()
 
 
@@ -175,10 +176,7 @@ def notify(event: str, data: dict | None = None):
     # Assign an event ID and buffer for reconnection
     eid = _next_event_id()
     with _recent_lock:
-        _recent_events.append((eid, event, data))
-        # Trim ring buffer
-        while len(_recent_events) > _RECENT_BUFFER_SIZE:
-            _recent_events.pop(0)
+        _recent_events.append((eid, event, data))  # deque auto-trims at maxlen
 
     stale = []
     with _clients_lock:


### PR DESCRIPTION
From /simplify review:
- **Shared SSE utility** (lib/sse.js) — eliminates duplicated backoff logic in Slideshow + Upload
- **deque ring buffer** — O(1) trim in sse.py instead of O(N) list.pop(0)
- **Timeout leak fix** — image error setTimeout now stored and cleared on unmount
- **Rename** onVideoEnded → onAdvance (handles both video end + image error)

Net: -88 lines of duplicated code, +64 lines of shared utility = 19 fewer lines total