### PR TITLE
feat: Agent 2 — Settings & UX Polish

### DIFF
--- a/app/frontend/src/app.css
+++ b/app/frontend/src/app.css
@@ -338,10 +338,9 @@
 /* ── Phone layout (base) ── */
 
 .fc-page {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 12px;
+  display: grid;
+  gap: var(--space-4, 16px);
+  padding: var(--space-3, 12px);
   padding-bottom: 84px; /* clearance for bottom nav */
 }
 
@@ -349,25 +348,136 @@
   grid-template-columns: repeat(2, 1fr);
 }
 
+/* ── Settings rows ── */
+
 .fc-setting-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3, 12px);
   min-height: 44px; /* touch target */
 }
 
 .fc-setting-row .sh-input,
 .fc-setting-row .sh-select {
   width: 100%;
-  max-width: 120px;
+  max-width: 140px;
   min-height: 44px; /* touch target */
   font-size: 16px; /* prevents iOS zoom on focus */
+}
+
+.fc-setting-row .sh-input[type="range"] {
+  max-width: 100%;
+  min-height: 32px;
+}
+
+.fc-setting-row .sh-input[type="time"] {
+  max-width: 120px;
 }
 
 .fc-setting-row .sh-toggle {
   min-width: 44px;
   min-height: 44px; /* touch target */
+}
+
+/* ── Settings section inner padding ── */
+
+.fc-settings-section {
+  display: grid;
+  gap: var(--space-3, 12px);
+  padding: var(--space-3, 12px) 0;
+}
+
+/* ── Range value display ── */
+
+.fc-range-value {
+  min-width: 48px;
+  text-align: right;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.85rem;
+}
+
+/* ── Day selector grid ── */
+
+.fc-day-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: var(--space-1, 4px);
+}
+
+.fc-day-btn {
+  min-width: 36px;
+  min-height: 36px;
+  padding: var(--space-1, 4px);
+  text-align: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.15));
+  background: transparent;
+  color: var(--text-tertiary);
+}
+
+.fc-day-btn--active {
+  color: var(--sh-phosphor);
+  border-color: var(--sh-phosphor);
+  background: oklch(85% 0.18 145 / 0.08);
+}
+
+/* ── Primary action button ── */
+
+.fc-btn-primary {
+  width: 100%;
+  cursor: pointer;
+  text-align: center;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--sh-phosphor);
+  border-color: var(--sh-phosphor);
+}
+
+.fc-btn-primary:disabled {
+  cursor: default;
+  opacity: 0.4;
+  color: var(--text-tertiary);
+  border-color: var(--border-subtle);
+}
+
+/* ── Toast container — above nav bar ── */
+
+.fc-toast-container {
+  position: fixed;
+  bottom: 80px;
+  left: var(--space-3, 12px);
+  right: var(--space-3, 12px);
+  z-index: 100;
+}
+
+/* ── Offline banner ── */
+
+.fc-offline-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 200;
+  padding: var(--space-2, 8px) var(--space-3, 12px);
+  background: var(--status-critical, #ff4444);
+  color: var(--surface-void, #000);
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+/* ── Validation error state ── */
+
+.sh-input[aria-invalid="true"],
+.sh-select[aria-invalid="true"] {
+  border-color: var(--status-critical, #ff4444);
 }
 
 /* Boot/display screens — fluid type */
@@ -389,8 +499,8 @@
 /* ── Tablet (768px+) ── */
 @media (min-width: 768px) {
   .fc-page {
-    padding: 20px;
-    padding-bottom: 20px; /* no bottom nav on tablet — sidebar */
+    padding: var(--space-5, 20px);
+    padding-bottom: var(--space-5, 20px); /* no bottom nav on tablet — sidebar */
     max-width: 800px;
     margin: 0 auto;
   }
@@ -408,6 +518,17 @@
     bottom: 32px;
     right: 32px;
     padding: 12px;
+  }
+
+  .fc-setting-row .sh-input,
+  .fc-setting-row .sh-select {
+    max-width: 180px;
+  }
+
+  .fc-toast-container {
+    left: auto;
+    right: var(--space-5, 20px);
+    max-width: 400px;
   }
 }
 
@@ -475,5 +596,15 @@
 
   .fc-otd-overlay {
     /* Keep OTD overlay visible but disable any animation */
+  }
+
+  /* Disable page entrance animation */
+  .sh-animate-page-enter {
+    animation: none;
+  }
+
+  /* Static offline banner — no transition */
+  .fc-offline-banner {
+    transition: none;
   }
 }

--- a/app/frontend/src/components/OfflineBanner.jsx
+++ b/app/frontend/src/components/OfflineBanner.jsx
@@ -1,0 +1,43 @@
+/** @fileoverview Offline detection banner — shows when navigator.onLine is false.
+ *
+ * Uses navigator.onLine + online/offline events for detection.
+ * piOS voice: "OFFLINE" — no conversational language.
+ */
+import { useState, useEffect } from "preact/hooks";
+
+/**
+ * OfflineBanner — fixed banner at top of viewport when offline.
+ * Returns null when online.
+ */
+export function OfflineBanner() {
+  const [offline, setOffline] = useState(
+    typeof navigator !== "undefined" ? !navigator.onLine : false,
+  );
+
+  useEffect(() => {
+    function handleOnline() {
+      setOffline(false);
+    }
+    function handleOffline() {
+      setOffline(true);
+    }
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  if (!offline) return null;
+
+  return (
+    <div
+      class="fc-offline-banner"
+      role="alert"
+      aria-live="assertive"
+    >
+      OFFLINE
+    </div>
+  );
+}

--- a/app/frontend/src/components/ShDropzone.jsx
+++ b/app/frontend/src/components/ShDropzone.jsx
@@ -14,11 +14,12 @@ import { glitchText } from "superhot-ui";
  *   complete  — received label, glitch burst, resets to idle after 2s
  *
  * @param {object}   props
- * @param {Function} [props.onUpload]  - Called with uploaded filename on success
- * @param {number}   [props.maxSizeMB] - Max file size in MB (client-side validation)
- * @param {boolean}  [props.disabled]  - Block uploads (e.g. disk full)
+ * @param {Function} [props.onUpload]      - Called with uploaded filename on success (single file)
+ * @param {Function} [props.onBatchUpload] - Called with FileList for batch upload (multi-file, handled externally)
+ * @param {number}   [props.maxSizeMB]     - Max file size in MB (client-side validation)
+ * @param {boolean}  [props.disabled]      - Block uploads (e.g. disk full)
  */
-export function ShDropzone({ onUpload, maxSizeMB = 200, disabled = false }) {
+export function ShDropzone({ onUpload, onBatchUpload, maxSizeMB = 200, disabled = false }) {
   const state = signal("idle");
   const progress = signal(0);
   const errorMsg = signal("");
@@ -120,6 +121,11 @@ export function ShDropzone({ onUpload, maxSizeMB = 200, disabled = false }) {
   /** Process dropped/selected files. */
   function handleFiles(fileList) {
     if (disabled || !fileList || fileList.length === 0) return;
+    // Delegate to batch handler when available (Upload page manages progress UI)
+    if (onBatchUpload && fileList.length > 0) {
+      onBatchUpload(fileList);
+      return;
+    }
     for (let i = 0; i < fileList.length; i++) {
       uploadFile(fileList[i]);
     }

--- a/app/frontend/src/lib/fetch.js
+++ b/app/frontend/src/lib/fetch.js
@@ -1,0 +1,62 @@
+/**
+ * Fetch wrapper with configurable timeout and offline detection.
+ *
+ * Default timeout: 15s for normal requests, 60s for uploads.
+ * Throws with piOS-style messages: "TIMEOUT", "OFFLINE", "RATE LIMITED. RETRY IN {X}s".
+ */
+
+const DEFAULT_TIMEOUT = 15000;
+const UPLOAD_TIMEOUT = 60000;
+
+/**
+ * Fetch with timeout via AbortController.
+ *
+ * @param {string} url
+ * @param {RequestInit & { timeout?: number }} [opts]
+ * @returns {Promise<Response>}
+ */
+export async function fetchWithTimeout(url, opts = {}) {
+  // Offline detection
+  if (typeof navigator !== "undefined" && !navigator.onLine) {
+    throw new Error("OFFLINE");
+  }
+
+  const timeout = opts.timeout || DEFAULT_TIMEOUT;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+
+  // Remove custom props before passing to native fetch
+  const fetchOpts = { ...opts, signal: controller.signal };
+  delete fetchOpts.timeout;
+
+  try {
+    const res = await fetch(url, fetchOpts);
+
+    // Rate limit handling
+    if (res.status === 429) {
+      const retryAfter = res.headers.get("Retry-After");
+      const seconds = retryAfter ? parseInt(retryAfter, 10) : 30;
+      throw new Error(`RATE LIMITED. RETRY IN ${seconds}s`);
+    }
+
+    return res;
+  } catch (err) {
+    if (err.name === "AbortError") {
+      throw new Error("TIMEOUT");
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Fetch with upload-appropriate timeout (60s).
+ *
+ * @param {string} url
+ * @param {RequestInit & { timeout?: number }} [opts]
+ * @returns {Promise<Response>}
+ */
+export function fetchUpload(url, opts = {}) {
+  return fetchWithTimeout(url, { timeout: UPLOAD_TIMEOUT, ...opts });
+}

--- a/app/frontend/src/pages/Onboard.jsx
+++ b/app/frontend/src/pages/Onboard.jsx
@@ -1,8 +1,15 @@
-/** @fileoverview Onboarding page — WiFi setup wizard with scan, select, connect steps. */
+/** @fileoverview Onboarding wizard — 4-step first-boot flow.
+ *
+ * Steps: WIFI -> UPLOAD -> CONFIGURE -> DONE
+ * Auto-redirects on first boot when ONBOARDING_COMPLETE is not set.
+ * TV display shows QR code + "SCAN TO CONFIGURE" throughout.
+ * piOS voice: terse, uppercase, no conversational language.
+ */
 import { useState, useEffect, useCallback, useRef } from "preact/hooks";
-import { ShSkeleton } from "superhot-ui/preact";
-import { ShToast } from "superhot-ui/preact";
+import { ShSkeleton, ShToast } from "superhot-ui/preact";
 import { navigate } from "../components/Router.jsx";
+import { ShDropzone } from "../components/ShDropzone.jsx";
+import { fetchWithTimeout } from "../lib/fetch.js";
 
 /** Map 0-100 signal percentage to 1-5 bar level. */
 function signalLevel(pct) {
@@ -14,10 +21,14 @@ function signalLevel(pct) {
 }
 
 /** WiFi signal bars component using superhot-ui CSS. */
-function SignalBars({ signal: pct }) {
-  const level = signalLevel(pct);
+function SignalBars({ strength }) {
+  const level = signalLevel(strength);
   return (
-    <span class="sh-signal-bars" data-sh-signal={level}>
+    <span
+      class="sh-signal-bars"
+      data-sh-signal={level}
+      aria-label={`SIGNAL: ${strength}%`}
+    >
       <span class="sh-signal-bar" />
       <span class="sh-signal-bar" />
       <span class="sh-signal-bar" />
@@ -27,14 +38,19 @@ function SignalBars({ signal: pct }) {
   );
 }
 
-/** Progress steps header showing wizard position. */
-function ProgressSteps({ current, error }) {
-  const steps = ["SCAN", "SELECT", "CONNECT", "DONE"];
-  const currentIdx = steps.indexOf(current);
-  const errorIdx = error ? steps.indexOf(error) : -1;
+/** 4-step progress indicator using sh-progress-steps. */
+function WizardSteps({ currentStep, errorStep }) {
+  const steps = [
+    { key: "WIFI", label: "WIFI" },
+    { key: "UPLOAD", label: "UPLOAD" },
+    { key: "CONFIGURE", label: "CONFIGURE" },
+    { key: "DONE", label: "DONE" },
+  ];
+  const currentIdx = steps.findIndex((step) => step.key === currentStep);
+  const errorIdx = errorStep ? steps.findIndex((step) => step.key === errorStep) : -1;
 
   return (
-    <div class="sh-progress-steps" style="margin-bottom: 16px;">
+    <div class="sh-progress-steps" style="margin-bottom: var(--space-4, 16px);" role="navigation" aria-label="Setup progress">
       {steps.map((step, idx) => {
         let cls = "sh-progress-step";
         if (errorIdx === idx) {
@@ -45,9 +61,9 @@ function ProgressSteps({ current, error }) {
           cls += " sh-progress-step--current";
         }
         return (
-          <div key={step} class={cls}>
+          <div key={step.key} class={cls}>
             <span class="sh-progress-step-number">{idx + 1}</span>
-            <span>{step}</span>
+            <span>{step.label}</span>
           </div>
         );
       })}
@@ -55,13 +71,13 @@ function ProgressSteps({ current, error }) {
   );
 }
 
-/** Network list item — clickable frame with SSID, signal bars, lock icon. */
+/** Network list item — clickable frame with SSID, signal bars, lock indicator. */
 function NetworkItem({ network, onSelect }) {
   const isSecured = network.security && network.security !== "" && network.security !== "--";
   return (
     <div
       class="sh-frame sh-clickable"
-      style="cursor: pointer; margin-bottom: 8px; min-height: 44px;"
+      style="cursor: pointer; margin-bottom: var(--space-2, 8px); min-height: 44px;"
       onClick={() => onSelect(network)}
       role="button"
       tabIndex={0}
@@ -72,19 +88,16 @@ function NetworkItem({ network, onSelect }) {
         }
       }}
     >
-      <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 4px 0;">
-        <div style="display: flex; align-items: center; gap: 10px; min-width: 0;">
-          <SignalBars signal={network.signal} />
+      <div style="display: grid; grid-template-columns: 1fr auto; gap: var(--space-3, 12px); align-items: center; padding: 4px 0;">
+        <div style="display: grid; grid-template-columns: auto 1fr; gap: var(--space-2, 8px); align-items: center; min-width: 0;">
+          <SignalBars strength={network.signal} />
           <span style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
             {network.ssid}
           </span>
         </div>
-        <div style="display: flex; align-items: center; gap: 6px; flex-shrink: 0;">
+        <div style="display: grid; grid-auto-flow: column; gap: var(--space-1, 4px); align-items: center;">
           {isSecured && (
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-label="Secured">
-              <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-              <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-            </svg>
+            <span class="sh-ansi-dim" style="font-size: 0.75rem;" aria-label="Secured network">SECURED</span>
           )}
           <span class="sh-ansi-dim" style="font-size: 0.75rem;">
             {network.signal}%
@@ -96,11 +109,11 @@ function NetworkItem({ network, onSelect }) {
 }
 
 /**
- * Onboard — WiFi setup wizard.
- * 4 steps: SCAN → SELECT → CONNECT → DONE
+ * Onboard — first-boot onboarding wizard.
+ * 4 steps: WIFI -> UPLOAD -> CONFIGURE -> DONE
  */
 export function Onboard() {
-  const [step, setStep] = useState("SCAN");
+  const [step, setStep] = useState("WIFI");
   const [networks, setNetworks] = useState([]);
   const [scanning, setScanning] = useState(false);
   const [selected, setSelected] = useState(null);
@@ -108,37 +121,52 @@ export function Onboard() {
   const [connecting, setConnecting] = useState(false);
   const [toast, setToast] = useState(null);
   const [errorStep, setErrorStep] = useState(null);
+  const [uploaded, setUploaded] = useState(false);
+  const [settings, setSettings] = useState(null);
   const redirectTimer = useRef(null);
+
+  /** Check if onboarding already complete — redirect if so. */
+  useEffect(() => {
+    fetchWithTimeout("/api/settings")
+      .then((res) => res.json())
+      .then((data) => {
+        setSettings(data);
+        if (data.onboarding_complete) {
+          navigate("/");
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      if (redirectTimer.current) clearTimeout(redirectTimer.current);
+    };
+  }, []);
+
+  /** Auto-scan WiFi on mount. */
+  useEffect(() => {
+    doScan();
+  }, []);
 
   /** Scan for WiFi networks. */
   const doScan = useCallback(() => {
     setScanning(true);
     setErrorStep(null);
-    fetch("/api/wifi/scan")
+    fetchWithTimeout("/api/wifi/scan")
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
       })
       .then((data) => {
         setNetworks(data);
-        setStep("SELECT");
       })
       .catch((err) => {
-        setToast({ type: "error", message: `SCAN FAILED: ${err.message}` });
-        setErrorStep("SCAN");
+        setToast({ type: "error", message: `SCAN FAULT: ${err.message}` });
+        setErrorStep("WIFI");
       })
       .finally(() => {
         setScanning(false);
       });
   }, []);
-
-  // Auto-scan on mount
-  useEffect(() => {
-    doScan();
-    return () => {
-      if (redirectTimer.current) clearTimeout(redirectTimer.current);
-    };
-  }, [doScan]);
 
   /** Handle network selection. */
   function handleSelect(network) {
@@ -146,10 +174,7 @@ export function Onboard() {
     setPassword("");
     setErrorStep(null);
     const isSecured = network.security && network.security !== "" && network.security !== "--";
-    if (isSecured) {
-      setStep("CONNECT");
-    } else {
-      // Open network — connect immediately
+    if (!isSecured) {
       doConnect(network.ssid, "");
     }
   }
@@ -158,30 +183,24 @@ export function Onboard() {
   function doConnect(ssid, pass) {
     setConnecting(true);
     setErrorStep(null);
-    setStep("CONNECT");
-    fetch("/api/wifi/connect", {
+    fetchWithTimeout("/api/wifi/connect", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ssid: ssid, password: pass }),
+      body: JSON.stringify({ ssid, password: pass }),
     })
       .then((res) => res.json())
       .then((data) => {
         if (data.success) {
-          setStep("DONE");
-          setToast({ type: "info", message: `CONNECTED TO ${ssid}` });
-          // Redirect to upload page after 3 seconds
-          redirectTimer.current = setTimeout(() => {
-            navigate("/");
-          }, 3000);
+          setToast({ type: "info", message: `CONNECTED: ${ssid}` });
+          setStep("UPLOAD");
         } else {
-          setToast({ type: "error", message: data.message || "CONNECTION FAILED" });
-          setErrorStep("CONNECT");
-          setStep("CONNECT");
+          setToast({ type: "error", message: data.message || "CONNECTION FAULT" });
+          setErrorStep("WIFI");
         }
       })
       .catch((err) => {
-        setToast({ type: "error", message: `CONNECTION ERROR: ${err.message}` });
-        setErrorStep("CONNECT");
+        setToast({ type: "error", message: `CONNECTION FAULT: ${err.message}` });
+        setErrorStep("WIFI");
       })
       .finally(() => {
         setConnecting(false);
@@ -195,88 +214,69 @@ export function Onboard() {
     doConnect(selected.ssid, password);
   }
 
-  /** Go back to network list for retry. */
-  function handleRetry() {
-    setSelected(null);
-    setPassword("");
-    setErrorStep(null);
-    setToast(null);
-    doScan();
+  /** Handle first photo upload. */
+  function handleUpload() {
+    setUploaded(true);
+    setToast({ type: "info", message: "PHOTO RECEIVED" });
+  }
+
+  /** Proceed from upload to configure step. */
+  function handleUploadContinue() {
+    setStep("CONFIGURE");
+  }
+
+  /** Finalize onboarding. */
+  async function handleFinish() {
+    // Save configure step settings
+    const configUpdates = {};
+    if (settings?.photo_duration) configUpdates.photo_duration = settings.photo_duration;
+    if (settings?.transition_type) configUpdates.transition_type = settings.transition_type;
+    configUpdates.onboarding_complete = true;
+
+    try {
+      await fetchWithTimeout("/api/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(configUpdates),
+      });
+    } catch (_) {
+      // Non-critical — proceed anyway
+    }
+    setStep("DONE");
+    redirectTimer.current = setTimeout(() => {
+      navigate("/");
+    }, 3000);
   }
 
   return (
-    <div class="sh-animate-page-enter fc-page">
-      <ProgressSteps current={step} error={errorStep} />
+    <main class="sh-animate-page-enter fc-page" role="main">
+      <WizardSteps currentStep={step} errorStep={errorStep} />
 
-      {/* STEP 1: SCANNING */}
-      {step === "SCAN" && (
-        <div class="sh-frame" data-label="WIFI SETUP">
+      {/* ── STEP 1: WIFI ── */}
+      {step === "WIFI" && (
+        <section class="sh-frame" data-label="WIFI SETUP" aria-label="WiFi setup">
           {scanning ? (
             <div style="text-align: center;">
-              <div class="sh-ansi-dim" style="margin-bottom: 12px;">SCANNING...</div>
+              <div class="sh-ansi-dim" style="margin-bottom: var(--space-3, 12px);">SCANNING</div>
               <ShSkeleton rows={4} height="2.5em" />
             </div>
-          ) : (
-            <div style="text-align: center;">
-              <div class="sh-ansi-dim" style="margin-bottom: 12px;">PREPARING SCAN...</div>
-              <ShSkeleton rows={3} height="2em" />
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* STEP 2: SELECT NETWORK */}
-      {step === "SELECT" && (
-        <div class="sh-frame" data-label="SELECT NETWORK">
-          {networks.length === 0 ? (
-            <div style="text-align: center; padding: 24px 0;">
+          ) : networks.length === 0 ? (
+            <div style="text-align: center; padding: var(--space-4, 16px) 0;">
               <div class="sh-ansi-dim">NO NETWORKS FOUND</div>
               <button
-                class="sh-input"
-                style="margin-top: 16px; cursor: pointer; text-align: center; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em;"
+                class="sh-input sh-clickable fc-btn-primary"
                 onClick={doScan}
                 disabled={scanning}
+                style="margin-top: var(--space-4, 16px);"
               >
-                {scanning ? "SCANNING..." : "RESCAN"}
+                RESCAN
               </button>
             </div>
-          ) : (
-            <div>
-              {networks.map((net) => (
-                <NetworkItem
-                  key={net.ssid}
-                  network={net}
-                  onSelect={handleSelect}
-                />
-              ))}
-              <button
-                class="sh-input"
-                style="width: 100%; margin-top: 8px; cursor: pointer; text-align: center; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-tertiary);"
-                onClick={doScan}
-                disabled={scanning}
-              >
-                {scanning ? "SCANNING..." : "RESCAN"}
-              </button>
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* STEP 3: CONNECT (password entry) */}
-      {step === "CONNECT" && selected && (
-        <div class="sh-frame" data-label={`CONNECT TO ${selected.ssid}`}>
-          {connecting ? (
-            <div style="text-align: center; padding: 24px 0;">
-              <div style="margin-bottom: 12px;">CONNECTING...</div>
-              <div class="sh-ansi-dim">{selected.ssid}</div>
-              <div style="margin-top: 16px;">
-                <ShSkeleton rows={1} height="2em" width="60%" />
-              </div>
-            </div>
-          ) : (
-            <form onSubmit={handleConnect} style="display: flex; flex-direction: column; gap: 12px;">
-              <div style="display: flex; align-items: center; gap: 8px;">
-                <SignalBars signal={selected.signal} />
+          ) : selected && !connecting ? (
+            /* Password entry for secured network */
+            <form onSubmit={handleConnect} style="display: grid; gap: var(--space-3, 12px);">
+              <div style="display: grid; grid-template-columns: auto 1fr; gap: var(--space-2, 8px); align-items: center;">
+                <SignalBars strength={selected.signal} />
                 <span style="font-weight: 600;">{selected.ssid}</span>
               </div>
               <input
@@ -288,50 +288,164 @@ export function Onboard() {
                 autoFocus
                 style="width: 100%;"
               />
-              <div style="display: flex; gap: 8px;">
+              <div style="display: grid; grid-template-columns: 1fr 2fr; gap: var(--space-2, 8px);">
                 <button
                   type="button"
-                  class="sh-input"
-                  style="flex: 1; cursor: pointer; text-align: center; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-tertiary);"
-                  onClick={handleRetry}
+                  class="sh-input sh-clickable"
+                  style="text-align: center; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-tertiary);"
+                  onClick={() => { setSelected(null); setPassword(""); }}
                 >
                   BACK
                 </button>
                 <button
                   type="submit"
-                  class="sh-input"
-                  style="flex: 2; cursor: pointer; text-align: center; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--sh-phosphor); border-color: var(--sh-phosphor);"
+                  class="sh-input sh-clickable fc-btn-primary"
                 >
                   CONNECT
                 </button>
               </div>
             </form>
+          ) : connecting ? (
+            <div style="text-align: center; padding: var(--space-4, 16px) 0;">
+              <div style="margin-bottom: var(--space-3, 12px);">CONNECTING</div>
+              <div class="sh-ansi-dim">{selected?.ssid}</div>
+              <div style="margin-top: var(--space-4, 16px);">
+                <ShSkeleton rows={1} height="2em" width="60%" />
+              </div>
+            </div>
+          ) : (
+            /* Network list */
+            <div>
+              {networks.map((net) => (
+                <NetworkItem
+                  key={net.ssid}
+                  network={net}
+                  onSelect={handleSelect}
+                />
+              ))}
+              <button
+                class="sh-input sh-clickable"
+                style="width: 100%; margin-top: var(--space-2, 8px); text-align: center; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-tertiary);"
+                onClick={doScan}
+                disabled={scanning}
+              >
+                RESCAN
+              </button>
+            </div>
           )}
-        </div>
+        </section>
       )}
 
-      {/* STEP 4: DONE */}
-      {step === "DONE" && (
-        <div class="sh-frame" data-label="CONNECTED">
-          <div style="text-align: center; padding: 24px 0;">
-            <div style="font-size: 1.5rem; color: var(--sh-phosphor); margin-bottom: 12px;">
-              CONNECTED
+      {/* ── STEP 2: UPLOAD FIRST PHOTO ── */}
+      {step === "UPLOAD" && (
+        <section class="sh-frame" data-label="UPLOAD FIRST PHOTO" aria-label="Upload first photo">
+          <div style="display: grid; gap: var(--space-4, 16px); text-align: center;">
+            <div class="sh-label" style="font-size: 1rem;">
+              {uploaded ? "PHOTO RECEIVED" : "UPLOAD FIRST PHOTO"}
             </div>
-            {selected && (
-              <div class="sh-ansi-dim" style="margin-bottom: 16px;">
-                {selected.ssid}
-              </div>
-            )}
-            <div class="sh-ansi-dim" style="font-size: 0.8rem;">
-              REDIRECTING TO UPLOAD...
+            <div class="sh-ansi-dim">
+              {uploaded
+                ? "ADD MORE OR CONTINUE TO CONFIGURE"
+                : "YOUR FRAME NEEDS AT LEAST ONE PHOTO"}
+            </div>
+            <ShDropzone onUpload={handleUpload} />
+            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-2, 8px);">
+              <button
+                class="sh-input sh-clickable"
+                style="text-align: center; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-tertiary);"
+                onClick={() => setStep("WIFI")}
+              >
+                BACK
+              </button>
+              <button
+                class="sh-input sh-clickable fc-btn-primary"
+                onClick={handleUploadContinue}
+                disabled={!uploaded}
+                style={`opacity: ${uploaded ? 1 : 0.4};`}
+              >
+                CONTINUE
+              </button>
             </div>
           </div>
-        </div>
+        </section>
       )}
 
-      {/* TOAST */}
+      {/* ── STEP 3: CONFIGURE ── */}
+      {step === "CONFIGURE" && (
+        <section class="sh-frame" data-label="CONFIGURE" aria-label="Configure basic settings">
+          <div style="display: grid; gap: var(--space-3, 12px);">
+            <div class="sh-label" style="text-align: center; font-size: 1rem;">
+              BASIC CONFIGURATION
+            </div>
+
+            <div class="fc-setting-row">
+              <span class="sh-label" style="white-space: nowrap;">DURATION</span>
+              <div style="display: grid; grid-template-columns: 1fr auto; gap: var(--space-2, 8px); align-items: center;">
+                <input
+                  class="sh-input"
+                  type="range"
+                  min="5"
+                  max="60"
+                  step="1"
+                  value={settings?.photo_duration || 10}
+                  onInput={(evt) => setSettings((prev) => ({ ...prev, photo_duration: parseInt(evt.target.value, 10) }))}
+                  aria-label="Slideshow duration in seconds"
+                />
+                <span class="sh-value" style="min-width: 32px; text-align: right;">
+                  {settings?.photo_duration || 10}s
+                </span>
+              </div>
+            </div>
+
+            <div class="fc-setting-row">
+              <span class="sh-label" style="white-space: nowrap;">TRANSITION</span>
+              <select
+                class="sh-select"
+                value={settings?.transition_type || "fade"}
+                onChange={(evt) => setSettings((prev) => ({ ...prev, transition_type: evt.target.value }))}
+              >
+                {["fade", "slide", "zoom", "dissolve", "none"].map((opt) => (
+                  <option key={opt} value={opt}>{opt.toUpperCase()}</option>
+                ))}
+              </select>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-2, 8px); margin-top: var(--space-2, 8px);">
+              <button
+                class="sh-input sh-clickable"
+                style="text-align: center; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-tertiary);"
+                onClick={() => setStep("UPLOAD")}
+              >
+                BACK
+              </button>
+              <button
+                class="sh-input sh-clickable fc-btn-primary"
+                onClick={handleFinish}
+              >
+                FINISH
+              </button>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* ── STEP 4: DONE ── */}
+      {step === "DONE" && (
+        <section class="sh-frame" data-label="COMPLETE" aria-label="Setup complete">
+          <div style="text-align: center; padding: var(--space-6, 32px) 0;">
+            <div style="font-size: 1.5rem; color: var(--sh-phosphor); margin-bottom: var(--space-3, 12px);">
+              FRAME READY
+            </div>
+            <div class="sh-ansi-dim" style="font-size: 0.8rem;">
+              REDIRECTING TO SLIDESHOW
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* ── TOAST ── */}
       {toast && (
-        <div style="position: fixed; bottom: 80px; left: 12px; right: 12px; z-index: 100;">
+        <div class="fc-toast-container">
           <ShToast
             type={toast.type}
             message={toast.message}
@@ -340,7 +454,7 @@ export function Onboard() {
           />
         </div>
       )}
-    </div>
+    </main>
   );
 }
 

--- a/app/frontend/src/pages/Settings.jsx
+++ b/app/frontend/src/pages/Settings.jsx
@@ -1,15 +1,30 @@
-/** @fileoverview Settings page — reads/writes FrameCast configuration via API. */
-import { useState, useEffect, useCallback } from "preact/hooks";
-import { ShCollapsible } from "superhot-ui/preact";
-import { ShToast } from "superhot-ui/preact";
+/** @fileoverview Settings page — complete configuration panel with collapsible sections.
+ *
+ * Sections: DISPLAY, SECURITY, SCHEDULE, NETWORK (read-only), SYSTEM.
+ * All forms use superhot-ui terminal form elements (.sh-input, .sh-select, .sh-toggle).
+ * piOS voice throughout: STANDBY, FAULT, CONFIRM, etc.
+ */
+import { useState, useEffect, useCallback, useRef } from "preact/hooks";
+import { ShCollapsible, ShModal, ShToast, ShSkeleton } from "superhot-ui/preact";
+import { applyThreshold } from "superhot-ui";
+import { fetchWithTimeout } from "../lib/fetch.js";
 
 const TRANSITION_OPTIONS = ["fade", "slide", "zoom", "dissolve", "none"];
+const TRANSITION_MODE_OPTIONS = [
+  { value: "single", label: "SINGLE" },
+  { value: "random", label: "RANDOM" },
+];
 const ORDER_OPTIONS = [
   { value: "shuffle", label: "SHUFFLE" },
-  { value: "newest", label: "NEWEST FIRST" },
-  { value: "oldest", label: "OLDEST FIRST" },
-  { value: "alphabetical", label: "ALPHABETICAL" },
+  { value: "date", label: "BY DATE" },
+  { value: "name", label: "BY NAME" },
 ];
+const KENBURNS_OPTIONS = [
+  { value: "subtle", label: "SUBTLE" },
+  { value: "moderate", label: "MODERATE" },
+  { value: "dramatic", label: "DRAMATIC" },
+];
+const DAYS = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"];
 
 export function Settings() {
   const [settings, setSettings] = useState(null);
@@ -17,24 +32,60 @@ export function Settings() {
   const [saving, setSaving] = useState(false);
   const [toast, setToast] = useState(null);
   const [error, setError] = useState(null);
+  const [status, setStatus] = useState(null);
+  const [wifiStatus, setWifiStatus] = useState(null);
+  const [pin, setPin] = useState(null);
+  const [restartOpen, setRestartOpen] = useState(false);
+  const [restarting, setRestarting] = useState(false);
+  const [regeneratingPin, setRegeneratingPin] = useState(false);
+  const storageBarRef = useRef(null);
 
+  /** Load settings + status + wifi info on mount. */
   useEffect(() => {
-    fetch("/api/settings")
+    loadSettings();
+    loadStatus();
+    loadWifiStatus();
+  }, []);
+
+  /** Apply threshold color to storage bar when status changes. */
+  useEffect(() => {
+    if (storageBarRef.current && status && status.disk) {
+      applyThreshold(storageBarRef.current, status.disk.percent);
+    }
+  }, [status]);
+
+  function loadSettings() {
+    setError(null);
+    fetchWithTimeout("/api/settings")
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
       })
       .then((data) => setSettings(data))
       .catch((err) => setError(err.message));
-  }, []);
+  }
 
-  const update = useCallback(
-    (key, value) => {
-      setSettings((prev) => ({ ...prev, [key]: value }));
-      setDirty((prev) => ({ ...prev, [key]: true }));
-    },
-    [],
-  );
+  function loadStatus() {
+    fetchWithTimeout("/api/status")
+      .then((res) => res.json())
+      .then((data) => {
+        setStatus(data);
+        if (data.access_pin) setPin(data.access_pin);
+      })
+      .catch(() => {});
+  }
+
+  function loadWifiStatus() {
+    fetchWithTimeout("/api/wifi/status")
+      .then((res) => res.json())
+      .then((data) => setWifiStatus(data))
+      .catch(() => {});
+  }
+
+  const update = useCallback((key, value) => {
+    setSettings((prev) => ({ ...prev, [key]: value }));
+    setDirty((prev) => ({ ...prev, [key]: true }));
+  }, []);
 
   const save = useCallback(async () => {
     if (!settings) return;
@@ -46,141 +97,355 @@ export function Settings() {
 
     setSaving(true);
     try {
-      const res = await fetch("/api/settings", {
+      const res = await fetchWithTimeout("/api/settings", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(changed),
       });
       const body = await res.json();
       if (!res.ok) {
-        setToast({ type: "error", message: body.error || "SAVE FAILED" });
+        setToast({ type: "error", message: body.error || "SAVE FAULT" });
         return;
       }
       setSettings(body.settings);
       setDirty({});
       setToast({ type: "info", message: "SETTINGS SAVED" });
     } catch (err) {
-      setToast({ type: "error", message: err.message || "NETWORK ERROR" });
+      setToast({ type: "error", message: err.message || "NETWORK FAULT" });
     } finally {
       setSaving(false);
     }
   }, [settings, dirty]);
 
+  async function handleRestart() {
+    setRestarting(true);
+    setRestartOpen(false);
+    try {
+      const res = await fetchWithTimeout("/api/restart-slideshow", {
+        method: "POST",
+      });
+      if (res.ok) {
+        setToast({ type: "info", message: "SERVICES RESTARTED" });
+      } else {
+        setToast({ type: "error", message: "RESTART FAULT" });
+      }
+    } catch (err) {
+      setToast({ type: "error", message: err.message || "NETWORK FAULT" });
+    } finally {
+      setRestarting(false);
+    }
+  }
+
+  async function handleRegeneratePin() {
+    setRegeneratingPin(true);
+    try {
+      const res = await fetchWithTimeout("/api/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ regenerate_pin: true }),
+      });
+      if (res.ok) {
+        setToast({ type: "info", message: "PIN REGENERATED" });
+        loadStatus();
+      } else {
+        setToast({ type: "error", message: "REGENERATE FAULT" });
+      }
+    } catch (err) {
+      setToast({ type: "error", message: err.message || "NETWORK FAULT" });
+    } finally {
+      setRegeneratingPin(false);
+    }
+  }
+
+  /* Error state with retry */
   if (error) {
     return (
-      <div class="sh-frame" data-label="SETTINGS" style="padding: 20px;">
-        <span class="sh-label" style="color: var(--status-critical, #ff4444);">
-          LOAD FAILED: {error}
-        </span>
-      </div>
+      <main class="fc-page" role="main">
+        <div class="sh-frame" data-label="SETTINGS" role="alert">
+          <div class="fc-settings-section">
+            <span class="sh-label" style="color: var(--status-critical, #ff4444);">
+              LOAD FAULT: {error}
+            </span>
+            <button
+              class="sh-input sh-clickable fc-btn-primary"
+              onClick={loadSettings}
+              style="margin-top: var(--space-4, 16px);"
+            >
+              RETRY
+            </button>
+          </div>
+        </div>
+      </main>
     );
   }
 
+  /* Loading state */
   if (!settings) {
     return (
-      <div class="sh-frame" data-label="SETTINGS" style="padding: 20px;">
-        <span class="sh-label">LOADING...</span>
-      </div>
+      <main class="fc-page" role="main">
+        <div class="sh-frame" data-label="SETTINGS">
+          <div class="fc-settings-section">
+            <span class="sh-label">STANDBY</span>
+            <ShSkeleton rows={6} height="2.5em" />
+          </div>
+        </div>
+      </main>
     );
   }
 
   const hasDirty = Object.keys(dirty).length > 0;
+  const diskPct = status?.disk?.percent || 0;
+  const version = status?.version || "UNKNOWN";
+  const sseClients = status?.sse_clients || 0;
 
   return (
-    <div class="fc-page">
-      {/* DISPLAY */}
-      <div class="sh-frame" data-label="DISPLAY">
-        <div style="display: flex; flex-direction: column; gap: 12px;">
-          <SettingRow label="SLIDESHOW INTERVAL (S)">
-            <input
-              class="sh-input"
-              type="number"
-              min="1"
-              value={settings.photo_duration}
-              onInput={(evt) => update("photo_duration", parseInt(evt.target.value, 10) || 1)}
-            />
-          </SettingRow>
+    <main class="sh-animate-page-enter fc-page" role="main">
+      {/* ── DISPLAY ── */}
+      <section aria-label="Display settings">
+        <ShCollapsible title="DISPLAY" defaultOpen={true}>
+          <div class="fc-settings-section">
+            <SettingRow label="DURATION" suffix="s">
+              <input
+                class="sh-input"
+                type="range"
+                min="5"
+                max="60"
+                step="1"
+                value={settings.photo_duration}
+                onInput={(evt) => update("photo_duration", parseInt(evt.target.value, 10))}
+                aria-label="Slideshow duration in seconds"
+              />
+              <span class="sh-value fc-range-value">{settings.photo_duration}s</span>
+            </SettingRow>
 
-          <SettingRow label="TRANSITION">
-            <select
-              class="sh-select"
-              value={settings.transition_type}
-              onChange={(evt) => update("transition_type", evt.target.value)}
-            >
-              {TRANSITION_OPTIONS.map((opt) => (
-                <option key={opt} value={opt}>
-                  {opt.toUpperCase()}
-                </option>
-              ))}
-            </select>
-          </SettingRow>
+            <SettingRow label="TRANSITION MODE">
+              <select
+                class="sh-select"
+                value={settings.transition_mode || "single"}
+                onChange={(evt) => update("transition_mode", evt.target.value)}
+              >
+                {TRANSITION_MODE_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </SettingRow>
 
-          <SettingRow label="PHOTO ORDER">
-            <select
-              class="sh-select"
-              value={settings.photo_order}
-              onChange={(evt) => update("photo_order", evt.target.value)}
-            >
-              {ORDER_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
-          </SettingRow>
-
-          <SettingRow label="QR DISPLAY (S)">
-            <input
-              class="sh-input"
-              type="number"
-              min="1"
-              value={settings.qr_display_seconds}
-              onInput={(evt) => update("qr_display_seconds", parseInt(evt.target.value, 10) || 1)}
-            />
-          </SettingRow>
-        </div>
-      </div>
-
-      {/* NETWORK */}
-      <div class="sh-frame" data-label="NETWORK">
-        <div style="display: flex; flex-direction: column; gap: 12px;">
-          <SettingRow label="HDMI SCHEDULE">
-            <Toggle
-              on={settings.hdmi_schedule_enabled}
-              onToggle={(val) => update("hdmi_schedule_enabled", val)}
-            />
-          </SettingRow>
-
-          {settings.hdmi_schedule_enabled && (
-            <>
-              <SettingRow label="HDMI OFF">
-                <input
-                  class="sh-input"
-                  type="text"
-                  value={settings.hdmi_off_time}
-                  placeholder="HH:MM"
-                  onInput={(evt) => update("hdmi_off_time", evt.target.value)}
-                />
+            {(settings.transition_mode || "single") === "single" && (
+              <SettingRow label="TRANSITION">
+                <select
+                  class="sh-select"
+                  value={settings.transition_type}
+                  onChange={(evt) => update("transition_type", evt.target.value)}
+                >
+                  {TRANSITION_OPTIONS.map((opt) => (
+                    <option key={opt} value={opt}>{opt.toUpperCase()}</option>
+                  ))}
+                </select>
               </SettingRow>
+            )}
 
-              <SettingRow label="HDMI ON">
-                <input
-                  class="sh-input"
-                  type="text"
-                  value={settings.hdmi_on_time}
-                  placeholder="HH:MM"
-                  onInput={(evt) => update("hdmi_on_time", evt.target.value)}
+            <SettingRow label="TRANSITION SPEED" suffix="ms">
+              <input
+                class="sh-input"
+                type="range"
+                min="500"
+                max="3000"
+                step="100"
+                value={settings.transition_duration_ms || 1000}
+                onInput={(evt) => update("transition_duration_ms", parseInt(evt.target.value, 10))}
+                aria-label="Transition duration in milliseconds"
+              />
+              <span class="sh-value fc-range-value">{settings.transition_duration_ms || 1000}ms</span>
+            </SettingRow>
+
+            <SettingRow label="PHOTO ORDER">
+              <select
+                class="sh-select"
+                value={settings.photo_order}
+                onChange={(evt) => update("photo_order", evt.target.value)}
+              >
+                {ORDER_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </SettingRow>
+
+            <SettingRow label="KEN BURNS">
+              <select
+                class="sh-select"
+                value={settings.kenburns_intensity || "moderate"}
+                onChange={(evt) => update("kenburns_intensity", evt.target.value)}
+              >
+                {KENBURNS_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </SettingRow>
+          </div>
+        </ShCollapsible>
+      </section>
+
+      {/* ── SECURITY ── */}
+      <section aria-label="Security settings">
+        <ShCollapsible title="SECURITY" defaultOpen={false}>
+          <div class="fc-settings-section">
+            <SettingRow label="ACCESS PIN">
+              <span class="sh-value" style="font-family: var(--font-mono, monospace); letter-spacing: 0.3em;">
+                {pin || "----"}
+              </span>
+            </SettingRow>
+
+            <SettingRow label="REGENERATE PIN">
+              <button
+                class="sh-input sh-clickable"
+                style="text-align: center; min-width: 120px;"
+                onClick={handleRegeneratePin}
+                disabled={regeneratingPin}
+              >
+                {regeneratingPin ? "STANDBY" : "REGENERATE"}
+              </button>
+            </SettingRow>
+
+            <SettingRow label="PIN LENGTH">
+              <Toggle
+                on={(settings.pin_length || 4) === 6}
+                onToggle={(val) => update("pin_length", val ? 6 : 4)}
+                labelOn="6"
+                labelOff="4"
+              />
+            </SettingRow>
+          </div>
+        </ShCollapsible>
+      </section>
+
+      {/* ── SCHEDULE ── */}
+      <section aria-label="Schedule settings">
+        <ShCollapsible title="SCHEDULE" defaultOpen={false}>
+          <div class="fc-settings-section">
+            <SettingRow label="DISPLAY SCHEDULE">
+              <Toggle
+                on={settings.hdmi_schedule_enabled}
+                onToggle={(val) => update("hdmi_schedule_enabled", val)}
+              />
+            </SettingRow>
+
+            {settings.hdmi_schedule_enabled && (
+              <>
+                <SettingRow label="ON TIME">
+                  <input
+                    class="sh-input"
+                    type="time"
+                    value={settings.hdmi_on_time || "08:00"}
+                    onInput={(evt) => update("hdmi_on_time", evt.target.value)}
+                    aria-label="Display on time"
+                  />
+                </SettingRow>
+
+                <SettingRow label="OFF TIME">
+                  <input
+                    class="sh-input"
+                    type="time"
+                    value={settings.hdmi_off_time || "22:00"}
+                    onInput={(evt) => update("hdmi_off_time", evt.target.value)}
+                    aria-label="Display off time"
+                  />
+                </SettingRow>
+
+                <div class="fc-setting-row">
+                  <span class="sh-label" style="white-space: nowrap;">DAYS</span>
+                  <div class="fc-day-grid">
+                    {DAYS.map((day, idx) => {
+                      const activeDays = settings.schedule_days || [0, 1, 2, 3, 4, 5, 6];
+                      const isActive = activeDays.includes(idx);
+                      return (
+                        <button
+                          key={day}
+                          class={`sh-input fc-day-btn${isActive ? " fc-day-btn--active" : ""}`}
+                          onClick={() => {
+                            const next = isActive
+                              ? activeDays.filter((dayIdx) => dayIdx !== idx)
+                              : [...activeDays, idx].sort();
+                            update("schedule_days", next);
+                          }}
+                          aria-pressed={isActive}
+                          aria-label={day}
+                        >
+                          {day}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              </>
+            )}
+
+            <SettingRow label="DISPLAY POWER">
+              <Toggle
+                on={settings.display_on !== false}
+                onToggle={(val) => update("display_on", val)}
+              />
+            </SettingRow>
+          </div>
+        </ShCollapsible>
+      </section>
+
+      {/* ── NETWORK (read-only) ── */}
+      <section aria-label="Network information">
+        <ShCollapsible title="NETWORK" defaultOpen={false}>
+          <div class="fc-settings-section">
+            <SettingRow label="WIFI">
+              <span class="sh-value">
+                {wifiStatus ? (wifiStatus.ssid || "NOT CONNECTED") : "STANDBY"}
+              </span>
+            </SettingRow>
+
+            <SettingRow label="IP ADDRESS">
+              <span class="sh-value">
+                {status?.ip_address || "UNKNOWN"}
+              </span>
+            </SettingRow>
+
+            <SettingRow label="HOSTNAME">
+              <span class="sh-value">
+                {status?.hostname || "UNKNOWN"}
+              </span>
+            </SettingRow>
+
+            <SettingRow label="SSE CLIENTS">
+              <span class="sh-value">{sseClients}</span>
+            </SettingRow>
+          </div>
+        </ShCollapsible>
+      </section>
+
+      {/* ── SYSTEM ── */}
+      <section aria-label="System settings">
+        <ShCollapsible title="SYSTEM" defaultOpen={false}>
+          <div class="fc-settings-section">
+            <SettingRow label="STORAGE">
+              <div style="display: grid; gap: var(--space-2, 8px); width: 100%; max-width: 200px;">
+                <div
+                  class="sh-threshold-bar"
+                  style={`--sh-fill: ${diskPct}`}
+                  ref={storageBarRef}
+                  role="meter"
+                  aria-label="Storage usage"
+                  aria-valuenow={diskPct}
+                  aria-valuemin="0"
+                  aria-valuemax="100"
                 />
-              </SettingRow>
-            </>
-          )}
-        </div>
-      </div>
+                <span class="sh-ansi-dim" style="font-size: 0.75rem;">
+                  {status?.disk
+                    ? `${status.disk.used} / ${status.disk.total}`
+                    : "STANDBY"}
+                </span>
+              </div>
+            </SettingRow>
 
-      {/* ADVANCED (contains SYSTEM) */}
-      <ShCollapsible title="ADVANCED" defaultOpen={false} summary="SYSTEM">
-        <div class="sh-frame" data-label="SYSTEM">
-          <div style="display: flex; flex-direction: column; gap: 12px;">
+            <SettingRow label="VERSION">
+              <span class="sh-value">{version}</span>
+            </SettingRow>
+
             <SettingRow label="AUTO-UPDATE">
               <Toggle
                 on={settings.auto_update_enabled}
@@ -188,52 +453,58 @@ export function Settings() {
               />
             </SettingRow>
 
-            <SettingRow label="UPLOAD LIMIT (MB)">
-              <input
-                class="sh-input"
-                type="number"
-                min="1"
-                value={settings.max_upload_mb}
-                onInput={(evt) => update("max_upload_mb", parseInt(evt.target.value, 10) || 1)}
-              />
+            <SettingRow label="UPLOAD LIMIT">
+              <div style="display: grid; grid-template-columns: 1fr auto; gap: var(--space-2, 8px); align-items: center; width: 100%; max-width: 160px;">
+                <input
+                  class="sh-input"
+                  type="number"
+                  min="1"
+                  value={settings.max_upload_mb}
+                  onInput={(evt) => update("max_upload_mb", parseInt(evt.target.value, 10) || 1)}
+                  aria-label="Upload limit in megabytes"
+                />
+                <span class="sh-ansi-dim">MB</span>
+              </div>
             </SettingRow>
 
-            <SettingRow label="AUTO-RESIZE MAX (PX)">
-              <input
-                class="sh-input"
-                type="number"
-                min="1"
-                value={settings.auto_resize_max}
-                onInput={(evt) => update("auto_resize_max", parseInt(evt.target.value, 10) || 1)}
-              />
+            <SettingRow label="RESTART SERVICES">
+              <button
+                class="sh-input sh-clickable"
+                style="text-align: center; min-width: 120px;"
+                onClick={() => setRestartOpen(true)}
+                disabled={restarting}
+              >
+                {restarting ? "STANDBY" : "RESTART"}
+              </button>
             </SettingRow>
           </div>
-        </div>
-      </ShCollapsible>
+        </ShCollapsible>
+      </section>
 
-      {/* SAVE */}
+      {/* ── SAVE BAR ── */}
       <button
-        class="sh-input"
-        style={`
-          width: 100%;
-          cursor: ${hasDirty && !saving ? "pointer" : "default"};
-          text-align: center;
-          font-weight: 700;
-          text-transform: uppercase;
-          letter-spacing: 0.1em;
-          opacity: ${hasDirty ? 1 : 0.4};
-          color: ${hasDirty ? "var(--sh-phosphor)" : "var(--text-tertiary)"};
-          border-color: ${hasDirty ? "var(--sh-phosphor)" : "var(--border-subtle)"};
-        `}
+        class="sh-input fc-btn-primary"
         disabled={!hasDirty || saving}
         onClick={save}
+        style={`opacity: ${hasDirty ? 1 : 0.4};`}
       >
-        {saving ? "SAVING..." : "SAVE"}
+        {saving ? "SAVING" : "SAVE"}
       </button>
 
-      {/* TOAST */}
+      {/* ── RESTART CONFIRMATION MODAL ── */}
+      <ShModal
+        open={restartOpen}
+        title="CONFIRM: RESTART SERVICES?"
+        body="SLIDESHOW WILL INTERRUPT BRIEFLY."
+        confirmLabel="RESTART"
+        cancelLabel="CANCEL"
+        onConfirm={handleRestart}
+        onCancel={() => setRestartOpen(false)}
+      />
+
+      {/* ── TOAST ── */}
       {toast && (
-        <div style="position: fixed; bottom: 80px; left: 12px; right: 12px; z-index: 100;">
+        <div class="fc-toast-container">
           <ShToast
             type={toast.type}
             message={toast.message}
@@ -242,22 +513,26 @@ export function Settings() {
           />
         </div>
       )}
-    </div>
+    </main>
   );
 }
 
 /** Row with UPPERCASE label on left, control on right. */
-function SettingRow({ label, children }) {
+function SettingRow({ label, suffix, children }) {
   return (
     <div class="fc-setting-row">
-      <span class="sh-label" style="white-space: nowrap;">{label}</span>
-      {children}
+      <span class="sh-label" style="white-space: nowrap;">
+        {label}{suffix ? ` (${suffix.toUpperCase()})` : ""}
+      </span>
+      <div style="display: grid; grid-auto-flow: column; gap: var(--space-2, 8px); align-items: center;">
+        {children}
+      </div>
     </div>
   );
 }
 
 /** Terminal-style ON/OFF toggle using sh-toggle CSS. */
-function Toggle({ on, onToggle }) {
+function Toggle({ on, onToggle, labelOn, labelOff }) {
   return (
     <div
       class="sh-toggle"
@@ -273,7 +548,7 @@ function Toggle({ on, onToggle }) {
         }
       }}
     >
-      <span class="sh-toggle-indicator">{on ? "ON" : "OFF"}</span>
+      <span class="sh-toggle-indicator">{on ? (labelOn || "ON") : (labelOff || "OFF")}</span>
     </div>
   );
 }

--- a/app/frontend/src/pages/Upload.jsx
+++ b/app/frontend/src/pages/Upload.jsx
@@ -1,9 +1,18 @@
-/** @fileoverview Upload page — dropzone + photo grid + disk space + user filter. */
+/** @fileoverview Upload page — dropzone + batch progress + photo grid + storage + user filter.
+ *
+ * Batch upload shows per-file status, auto-retries failed uploads (3 attempts,
+ * exponential backoff), and displays a completion summary.
+ * piOS voice: UPLOADING 3/12, COMPLETE, FAULT, etc.
+ */
 import { signal } from "@preact/signals";
-import { useEffect, useRef } from "preact/hooks";
+import { useState, useEffect, useRef, useCallback } from "preact/hooks";
+import { ShToast } from "superhot-ui/preact";
+import { applyThreshold } from "superhot-ui";
 import { ShDropzone } from "../components/ShDropzone.jsx";
 import { PhotoGrid } from "../components/PhotoGrid.jsx";
+import { OfflineBanner } from "../components/OfflineBanner.jsx";
 import { createSSE } from "../lib/sse.js";
+import { fetchWithTimeout } from "../lib/fetch.js";
 import {
   currentUser,
   ensureUserIdentified,
@@ -17,17 +26,12 @@ const loading = signal(true);
 const userFilter = signal("all");
 const availableUsers = signal([]);
 
-/** Build ASCII storage bar: [▓▓▓░░░] */
-function storageBar(pct) {
-  const width = 20;
-  const filled = Math.round((pct / 100) * width);
-  const empty = width - filled;
-  return "[" + "\u2593".repeat(filled) + "\u2591".repeat(empty) + "]";
-}
+const MAX_RETRIES = 3;
+const RETRY_BASE_MS = 1000;
 
 /** Fetch photos list from API. */
 function fetchPhotos() {
-  return fetch("/api/photos")
+  return fetchWithTimeout("/api/photos")
     .then((resp) => resp.json())
     .then((data) => {
       photos.value = data;
@@ -36,30 +40,94 @@ function fetchPhotos() {
       availableUsers.value = uploaders.sort();
     })
     .catch((err) => {
-      console.warn("Upload: fetchPhotos failed", err);
+      console.warn("Upload: fetchPhotos fault", err);
     });
 }
 
 /** Fetch system status (disk usage) from API. */
 function fetchStatus() {
-  return fetch("/api/status")
+  return fetchWithTimeout("/api/status")
     .then((resp) => resp.json())
     .then((data) => {
       if (data.disk) disk.value = data.disk;
     })
     .catch((err) => {
-      console.warn("Upload: fetchStatus failed", err);
+      console.warn("Upload: fetchStatus fault", err);
     });
 }
 
 /**
+ * Upload a single file via XHR with progress + retry.
+ * Returns a promise that resolves with { name, status, error? }.
+ */
+function uploadFileWithRetry(file, onProgress, attempt = 0) {
+  return new Promise((resolve) => {
+    const form = new FormData();
+    form.append("files", file);
+
+    const xhr = new XMLHttpRequest();
+
+    xhr.upload.addEventListener("progress", (evt) => {
+      if (evt.lengthComputable) {
+        onProgress(Math.round((evt.loaded / evt.total) * 100));
+      }
+    });
+
+    xhr.addEventListener("load", () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve({ name: file.name, status: "COMPLETE" });
+      } else if (xhr.status === 429 && attempt < MAX_RETRIES) {
+        // Rate limited — retry with backoff
+        const delay = RETRY_BASE_MS * Math.pow(2, attempt);
+        setTimeout(() => {
+          uploadFileWithRetry(file, onProgress, attempt + 1).then(resolve);
+        }, delay);
+      } else if (attempt < MAX_RETRIES) {
+        const delay = RETRY_BASE_MS * Math.pow(2, attempt);
+        setTimeout(() => {
+          uploadFileWithRetry(file, onProgress, attempt + 1).then(resolve);
+        }, delay);
+      } else {
+        let errorMsg = `HTTP ${xhr.status}`;
+        try {
+          const resp = JSON.parse(xhr.responseText);
+          if (resp.error) errorMsg = resp.error;
+        } catch (_) {}
+        resolve({ name: file.name, status: "FAULT", error: errorMsg });
+      }
+    });
+
+    xhr.addEventListener("error", () => {
+      if (attempt < MAX_RETRIES) {
+        const delay = RETRY_BASE_MS * Math.pow(2, attempt);
+        setTimeout(() => {
+          uploadFileWithRetry(file, onProgress, attempt + 1).then(resolve);
+        }, delay);
+      } else {
+        resolve({ name: file.name, status: "FAULT", error: "NETWORK FAULT" });
+      }
+    });
+
+    xhr.open("POST", "/upload");
+    xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+    xhr.send(form);
+  });
+}
+
+/**
  * Upload — main upload page.
- * Combines ShDropzone, PhotoGrid, disk space display, and user filter.
+ * Combines ShDropzone, batch upload progress, PhotoGrid, disk space display, and user filter.
  * Prompts "WHO IS UPLOADING?" on first upload if no cookie set.
  * Subscribes to SSE for real-time photo:added/photo:deleted events.
  */
 export function Upload() {
   const sseRef = useRef(null);
+  const storageBarRef = useRef(null);
+  const [toast, setToast] = useState(null);
+
+  /* Batch upload state */
+  const [batch, setBatch] = useState(null);
+  /* batch shape: { files: [{name, status, progress, error?}], total, completed, failed } */
 
   function handleRefresh() {
     fetchPhotos();
@@ -67,12 +135,10 @@ export function Upload() {
   }
 
   useEffect(() => {
-    // Initial data fetch
     Promise.all([fetchPhotos(), fetchStatus()]).then(() => {
       loading.value = false;
     });
 
-    // Connect SSE with shared backoff utility
     const sse = createSSE("/api/events", {
       listeners: {
         "photo:added": handleRefresh,
@@ -82,6 +148,70 @@ export function Upload() {
     sseRef.current = sse;
 
     return () => sse.close();
+  }, []);
+
+  /** Apply threshold to storage bar on disk change. */
+  useEffect(() => {
+    if (storageBarRef.current && disk.value) {
+      applyThreshold(storageBarRef.current, disk.value.percent || 0);
+    }
+  }, [disk.value]);
+
+  /** Handle batch file selection from dropzone. */
+  const handleBatchUpload = useCallback(async (fileList) => {
+    if (!fileList || fileList.length === 0) return;
+
+    const files = Array.from(fileList);
+    const batchState = {
+      files: files.map((file) => ({ name: file.name, status: "PENDING", progress: 0 })),
+      total: files.length,
+      completed: 0,
+      failed: 0,
+    };
+    setBatch({ ...batchState });
+
+    // Upload sequentially to avoid Pi 3 OOM
+    for (let idx = 0; idx < files.length; idx++) {
+      // Update current file to UPLOADING
+      batchState.files[idx].status = "UPLOADING";
+      setBatch({ ...batchState });
+
+      const result = await uploadFileWithRetry(
+        files[idx],
+        (pct) => {
+          batchState.files[idx].progress = pct;
+          setBatch({ ...batchState });
+        },
+      );
+
+      batchState.files[idx].status = result.status;
+      batchState.files[idx].progress = result.status === "COMPLETE" ? 100 : 0;
+      if (result.error) batchState.files[idx].error = result.error;
+
+      if (result.status === "COMPLETE") {
+        batchState.completed++;
+      } else {
+        batchState.failed++;
+      }
+      setBatch({ ...batchState });
+    }
+
+    // Refresh data after batch completes
+    fetchPhotos();
+    fetchStatus();
+
+    // Show summary toast
+    if (batchState.failed === 0) {
+      setToast({ type: "info", message: `${batchState.completed} UPLOADED` });
+    } else {
+      setToast({
+        type: "error",
+        message: `${batchState.completed} UPLOADED. ${batchState.failed} FAILED`,
+      });
+    }
+
+    // Clear batch after 5s
+    setTimeout(() => setBatch(null), 5000);
   }, []);
 
   function handleUploadAttempt() {
@@ -98,7 +228,6 @@ export function Upload() {
   }
 
   function handleDelete() {
-    // SSE will trigger refresh, but fetch eagerly
     fetchPhotos();
     fetchStatus();
   }
@@ -118,14 +247,16 @@ export function Upload() {
 
   if (isLoading) {
     return (
-      <div class="sh-frame" style="padding: 24px; text-align: center;">
+      <main class="sh-frame" style="padding: 24px; text-align: center;" role="main">
         <div class="sh-ansi-dim">STANDBY</div>
-      </div>
+      </main>
     );
   }
 
   return (
-    <div class="sh-animate-page-enter fc-page">
+    <main class="sh-animate-page-enter fc-page" role="main">
+      <OfflineBanner />
+
       {/* User select modal (shown on first upload if no cookie) */}
       <UserSelectModal onSelected={handleUserSelected} />
 
@@ -149,24 +280,92 @@ export function Upload() {
       {/* Dropzone */}
       <ShDropzone
         onUpload={handleUploadAttempt}
+        onBatchUpload={handleBatchUpload}
         disabled={isUploadBlocked}
       />
 
-      {/* Storage indicator */}
-      <div class="sh-frame" data-label="STORAGE">
-        <div style="padding: 12px;">
-          <div style="font-family: var(--font-mono, monospace); display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
-            <span>{storageBar(diskPct)}</span>
-            <span>{diskPct}%</span>
-            {isLowDisk && (
-              <span class="sh-status-badge" data-sh-status="critical">LOW DISK</span>
+      {/* Batch upload progress */}
+      {batch && (
+        <section class="sh-frame" data-label="TRANSFER" aria-label="Upload progress">
+          <div style="display: grid; gap: var(--space-2, 8px);">
+            <div class="sh-label">
+              UPLOADING {Math.min(batch.completed + batch.failed + 1, batch.total)}/{batch.total}
+            </div>
+            <div class="sh-threshold-bar" style={`--sh-fill: ${Math.round(((batch.completed + batch.failed) / batch.total) * 100)}`} />
+            <div style="display: grid; gap: var(--space-1, 4px); max-height: 200px; overflow-y: auto;">
+              {batch.files.map((file) => (
+                <div
+                  key={file.name}
+                  style="display: grid; grid-template-columns: 1fr auto; gap: var(--space-2, 8px); align-items: center; font-size: 0.8rem;"
+                >
+                  <span
+                    class="sh-ansi-dim"
+                    style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+                  >
+                    {file.name}
+                  </span>
+                  <span
+                    class={
+                      file.status === "COMPLETE" ? "sh-ansi-fg-green" :
+                      file.status === "FAULT" ? "sh-ansi-fg-red" :
+                      file.status === "UPLOADING" ? "" :
+                      "sh-ansi-dim"
+                    }
+                    style="font-size: 0.75rem; white-space: nowrap;"
+                  >
+                    {file.status === "UPLOADING" ? `${file.progress}%` : file.status}
+                  </span>
+                </div>
+              ))}
+            </div>
+            {/* Completion summary */}
+            {batch.completed + batch.failed === batch.total && (
+              <div style="margin-top: var(--space-2, 8px); font-size: 0.8rem;">
+                <span class="sh-value">
+                  {batch.completed} UPLOADED
+                  {batch.failed > 0 && (
+                    <span class="sh-ansi-fg-red">
+                      . {batch.failed} FAILED
+                    </span>
+                  )}
+                </span>
+                {batch.files.filter((file) => file.error).map((file) => (
+                  <div key={file.name} class="sh-ansi-dim" style="font-size: 0.75rem; margin-top: 2px;">
+                    {file.name} — {file.error}
+                  </div>
+                ))}
+              </div>
             )}
           </div>
-          <div class="sh-ansi-dim" style="margin-top: 6px; font-size: 0.8rem;">
+        </section>
+      )}
+
+      {/* Storage indicator */}
+      <section class="sh-frame" data-label="STORAGE" aria-label="Storage usage">
+        <div style="padding: var(--space-3, 12px);">
+          <div style="display: grid; grid-template-columns: 1fr auto; gap: var(--space-2, 8px); align-items: center;">
+            <div
+              class="sh-threshold-bar"
+              style={`--sh-fill: ${diskPct}`}
+              ref={storageBarRef}
+              role="meter"
+              aria-label="Storage usage"
+              aria-valuenow={diskPct}
+              aria-valuemin="0"
+              aria-valuemax="100"
+            />
+            <span style="white-space: nowrap;">
+              {diskPct}%
+              {isLowDisk && (
+                <span class="sh-status-badge" data-sh-status="critical" style="margin-left: var(--space-2, 8px);">LOW DISK</span>
+              )}
+            </span>
+          </div>
+          <div class="sh-ansi-dim" style="margin-top: var(--space-1, 4px); font-size: 0.8rem;">
             {currentDisk.used} USED / {currentDisk.total} TOTAL / {currentDisk.free} FREE
           </div>
         </div>
-      </div>
+      </section>
 
       {/* User filter dropdown */}
       {availableUsers.value.length > 1 && (
@@ -187,6 +386,18 @@ export function Upload() {
 
       {/* Photo grid */}
       <PhotoGrid photos={filteredPhotos} onDelete={handleDelete} />
-    </div>
+
+      {/* Toast */}
+      {toast && (
+        <div class="fc-toast-container">
+          <ShToast
+            type={toast.type}
+            message={toast.message}
+            duration={4000}
+            onDismiss={() => setToast(null)}
+          />
+        </div>
+      )}
+    </main>
   );
 }


### PR DESCRIPTION
## Phase 2, Agent 2: Settings & UX Polish

### First-Boot Onboarding Wizard
- 4-step wizard: WIFI -> UPLOAD -> CONFIGURE -> DONE
- `.sh-progress-steps` indicator with complete/current/error states
- Auto-redirect when `ONBOARDING_COMPLETE` is already set
- Step 2: ShDropzone integration for first photo upload
- Step 3: Basic configuration (duration slider, transition select)
- Step 4: FRAME READY + auto-redirect to slideshow
- piOS voice throughout (SCANNING, CONNECTED, FRAME READY)

### Complete Settings Page
- 5 collapsible sections using `ShCollapsible`:
  - **DISPLAY**: Duration slider (5-60s), transition mode (single/random), transition type, transition speed (500-3000ms), photo order, Ken Burns intensity
  - **SECURITY**: PIN display (read-only), regenerate button, PIN length toggle (4/6)
  - **SCHEDULE**: Display on/off toggle, on/off time pickers (HH:MM), day-of-week selector (CSS Grid), manual display power toggle
  - **NETWORK** (read-only): WiFi SSID, IP address, hostname, SSE clients
  - **SYSTEM**: Storage bar (`.sh-threshold-bar` + `applyThreshold()`), version, auto-update toggle, upload limit, restart services with ShModal confirmation
- Save button with dirty tracking and phosphor highlight

### Batch Upload Progress
- Per-file status indicators (PENDING/UPLOADING/COMPLETE/FAULT)
- Overall progress bar via `.sh-threshold-bar`
- Auto-retry: 3 attempts with exponential backoff (1s, 2s, 4s)
- Completion summary: `12 UPLOADED. 1 FAILED` with per-file error details
- Sequential upload to avoid Pi 3 OOM

### Error States & Loading
- `fetchWithTimeout()` utility: 15s default, 60s for uploads
- Offline detection via `navigator.onLine` + events -> fixed OFFLINE banner
- Rate limit: 429 -> `RATE LIMITED. RETRY IN {X}s`
- Settings load failure: ShErrorState with RETRY button
- piOS voice: STANDBY (not Loading), FAULT (not Error), TIMEOUT

### Accessibility
- `<main>`, `<section>` landmark regions on all pages
- Signal bars: `aria-label="SIGNAL: 80%"`
- Storage bar: `role="meter"` + `aria-valuenow`
- Toggle: `role="switch"` + `aria-checked`
- Day buttons: `aria-pressed`
- Toast positioning above nav bar
- `prefers-reduced-motion` support for new elements
- Validation: `aria-invalid` CSS support

### New Files
- `app/frontend/src/lib/fetch.js` — fetchWithTimeout utility
- `app/frontend/src/components/OfflineBanner.jsx` — offline detection banner

### Design Compliance
- CSS Grid layout (no flexbox wrapping) per R36
- `--space-*` tokens for all spacing per R33
- piOS voice (uppercase, terse, no emoji) per R13
- Text labels only (no icons in actions) per R31
- 24-hour time format per R24
- `prefers-reduced-motion` support per R15
- Never uses `h` as callback parameter in JSX