### PR TITLE
feat: Agent 3 — Favorites + Albums

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -161,9 +161,20 @@ _SETTINGS_ENV_MAP = {
 
 @api.route("/photos")
 def list_photos():
-    """Return all media files as JSON from database."""
+    """Return media files as JSON from database.
+
+    Query params:
+        filter: 'favorites' | 'hidden' | omit for default (non-hidden, non-quarantined)
+    """
     try:
-        photos = db.get_photos()
+        photo_filter = request.args.get("filter", "")
+        favorite_only = photo_filter == "favorites"
+        include_hidden = photo_filter == "hidden"
+
+        photos = db.get_photos(
+            favorite_only=favorite_only,
+            include_hidden=include_hidden,
+        )
         # Augment with human-readable size for frontend compatibility
         for photo in photos:
             photo["name"] = photo["filename"]
@@ -382,6 +393,26 @@ def delete_album_endpoint(album_id):
     return jsonify({"status": "ok"})
 
 
+@api.route("/albums/<int:album_id>/photos")
+def list_album_photos(album_id):
+    """Return all photos in an album."""
+    photos = db.get_album_photos(album_id)
+    for photo in photos:
+        photo["name"] = photo["filename"]
+        photo["size_human"] = media.format_size(photo.get("file_size") or 0)
+    return jsonify(photos)
+
+
+@api.route("/albums/smart/<smart_key>/photos")
+def list_smart_album_photos(smart_key):
+    """Return photos matching a smart album query."""
+    photos = db.get_smart_album_photos(smart_key)
+    for photo in photos:
+        photo["name"] = photo["filename"]
+        photo["size_human"] = media.format_size(photo.get("file_size") or 0)
+    return jsonify(photos)
+
+
 @api.route("/albums/<int:album_id>/photos", methods=["POST"])
 @require_pin
 def add_photo_to_album(album_id):
@@ -409,6 +440,13 @@ def remove_photo_from_album(album_id, photo_id):
 # ---------------------------------------------------------------------------
 # Tag endpoints
 # ---------------------------------------------------------------------------
+
+
+@api.route("/tags")
+def list_all_tags():
+    """Return all tags for autocomplete."""
+    tags = db.get_all_tags()
+    return jsonify(tags)
 
 
 @api.route("/photos/<int:photo_id>/tags")

--- a/app/frontend/src/app.css
+++ b/app/frontend/src/app.css
@@ -557,7 +557,55 @@
 }
 
 /* ================================================================
-   9. Utility — reduced motion
+   9. Favorites & Albums — PhotoCard, Context Menu, Lightbox
+   ================================================================ */
+
+/* Favorite card — phosphor left border */
+.fc-card--favorite {
+  border-left: 2px solid var(--sh-phosphor);
+}
+
+/* Context menu items */
+.fc-ctx-item {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 8px 14px;
+  text-align: left;
+  cursor: pointer;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.fc-ctx-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-left: 2px solid var(--sh-phosphor);
+}
+
+.fc-ctx-item--danger {
+  color: var(--sh-threat, #ff4444);
+}
+
+/* Lightbox action buttons */
+.fc-action-btn {
+  font-family: var(--font-mono, monospace);
+}
+
+.fc-action-btn--active {
+  color: var(--sh-phosphor);
+  border-color: var(--sh-phosphor);
+}
+
+.fc-action-btn--danger {
+  color: var(--sh-threat, #ff4444);
+  border-color: var(--sh-threat, #ff4444);
+}
+
+/* ================================================================
+   10. Utility — reduced motion
    ================================================================ */
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/frontend/src/app.jsx
+++ b/app/frontend/src/app.jsx
@@ -6,6 +6,7 @@ import { Upload } from "./pages/Upload.jsx";
 import { Settings } from "./pages/Settings.jsx";
 import { Map } from "./pages/Map.jsx";
 import { Update } from "./pages/Update.jsx";
+import { Albums } from "./pages/Albums.jsx";
 import { Onboard } from "./pages/Onboard.jsx";
 import { Stats } from "./pages/Stats.jsx";
 import { Users } from "./pages/Users.jsx";
@@ -22,6 +23,7 @@ function isDisplay() {
 // --- Route definitions ---
 const phoneRoutes = [
   { path: "/", component: Upload },
+  { path: "/albums", component: Albums },
   { path: "/settings", component: Settings },
   { path: "/map", component: Map },
   { path: "/stats", component: Stats },

--- a/app/frontend/src/components/Lightbox.jsx
+++ b/app/frontend/src/components/Lightbox.jsx
@@ -1,0 +1,388 @@
+/** @fileoverview Lightbox — full-screen photo viewer with swipe navigation and actions. */
+import { signal } from "@preact/signals";
+import { useEffect, useRef, useCallback } from "preact/hooks";
+import { formatTime } from "superhot-ui";
+
+/** Lightbox state: { photos, index } or null when closed. */
+export const lightboxState = signal(null);
+
+/**
+ * Open the lightbox at a given photo within a list.
+ * @param {Array} photos - Full photo list for navigation
+ * @param {number} index - Starting index
+ */
+export function openLightbox(photos, index) {
+  lightboxState.value = { photos, index };
+}
+
+/** Close the lightbox. */
+export function closeLightbox() {
+  lightboxState.value = null;
+}
+
+/**
+ * Lightbox — full-screen overlay photo viewer.
+ *
+ * Features:
+ * - Swipe left/right to navigate (touch events)
+ * - Bottom action bar: [FAV], [TAG], [DELETE], [INFO]
+ * - Info panel with EXIF date, upload date, view count, file size, dimensions
+ * - Escape or overlay tap to close
+ */
+export function Lightbox({ onToggleFavorite, onDelete, onAddTag, onRemoveTag, tags }) {
+  const state = lightboxState.value;
+  const overlayRef = useRef(null);
+  const touchStartX = useRef(0);
+  const touchStartY = useRef(0);
+  const infoOpen = signal(false);
+  const tagInput = signal("");
+  const tagSuggestions = signal([]);
+  const allTags = signal([]);
+
+  // Fetch all tags for autocomplete
+  useEffect(() => {
+    if (!state) return;
+    fetch("/api/tags")
+      .then((resp) => resp.ok ? resp.json() : [])
+      .then((data) => { allTags.value = data; })
+      .catch(() => { allTags.value = []; });
+  }, [state ? 1 : 0]);
+
+  // Fetch tags for current photo
+  useEffect(() => {
+    if (!state) return;
+    const photo = state.photos[state.index];
+    if (!photo || !photo.id) return;
+    fetch(`/api/photos/${photo.id}/tags`)
+      .then((resp) => resp.ok ? resp.json() : [])
+      .then((data) => { tagSuggestions.value = data; })
+      .catch(() => { tagSuggestions.value = []; });
+  }, [state ? state.index : -1]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!state) return;
+    function handleKey(evt) {
+      if (evt.key === "Escape") closeLightbox();
+      else if (evt.key === "ArrowLeft") navigate(-1);
+      else if (evt.key === "ArrowRight") navigate(1);
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [state]);
+
+  if (!state) return null;
+
+  const { photos: photoList, index } = state;
+  const photo = photoList[index];
+  if (!photo) {
+    closeLightbox();
+    return null;
+  }
+
+  function navigate(direction) {
+    const newIndex = index + direction;
+    if (newIndex >= 0 && newIndex < photoList.length) {
+      lightboxState.value = { photos: photoList, index: newIndex };
+    }
+  }
+
+  // Touch swipe handlers
+  function handleTouchStart(evt) {
+    touchStartX.current = evt.touches[0].clientX;
+    touchStartY.current = evt.touches[0].clientY;
+  }
+
+  function handleTouchEnd(evt) {
+    const dx = evt.changedTouches[0].clientX - touchStartX.current;
+    const dy = evt.changedTouches[0].clientY - touchStartY.current;
+    const absDx = Math.abs(dx);
+    const absDy = Math.abs(dy);
+
+    // Horizontal swipe (must be dominant axis, min 50px)
+    if (absDx > 50 && absDx > absDy * 1.5) {
+      if (dx > 0) navigate(-1); // swipe right = previous
+      else navigate(1);          // swipe left = next
+    }
+    // Downward swipe to close
+    else if (dy > 80 && absDy > absDx * 1.5) {
+      closeLightbox();
+    }
+  }
+
+  function handleOverlayClick(evt) {
+    if (evt.target === overlayRef.current) closeLightbox();
+  }
+
+  function handleFav() {
+    if (onToggleFavorite) onToggleFavorite(photo);
+  }
+
+  function handleDeleteAction() {
+    if (onDelete) onDelete(photo);
+    closeLightbox();
+  }
+
+  function toggleInfo() {
+    infoOpen.value = !infoOpen.value;
+  }
+
+  // Tag input handling
+  function handleTagKeyDown(evt) {
+    if (evt.key === "Enter") {
+      const name = tagInput.value.trim();
+      if (name && onAddTag) {
+        onAddTag(photo, name);
+        tagInput.value = "";
+        // Refresh tags
+        setTimeout(() => {
+          fetch(`/api/photos/${photo.id}/tags`)
+            .then((resp) => resp.ok ? resp.json() : [])
+            .then((data) => { tagSuggestions.value = data; })
+            .catch(() => {});
+        }, 300);
+      }
+    }
+  }
+
+  function handleRemoveTag(tag) {
+    if (onRemoveTag) {
+      onRemoveTag(photo, tag);
+      // Refresh tags
+      setTimeout(() => {
+        fetch(`/api/photos/${photo.id}/tags`)
+          .then((resp) => resp.ok ? resp.json() : [])
+          .then((data) => { tagSuggestions.value = data; })
+          .catch(() => {});
+      }, 300);
+    }
+  }
+
+  // Filter autocomplete suggestions
+  const currentInput = tagInput.value.toLowerCase();
+  const currentTagIds = new Set((tagSuggestions.value || []).map((tg) => tg.id));
+  const autoSuggestions = currentInput.length > 0
+    ? (allTags.value || []).filter(
+        (tg) => tg.name.toLowerCase().includes(currentInput) && !currentTagIds.has(tg.id)
+      ).slice(0, 5)
+    : [];
+
+  const filename = photo.name || photo.filename;
+  const photoSrc = photo.is_video ? `/thumbnail/${filename}` : `/media/${filename}`;
+
+  // Format file size
+  function formatSize(bytes) {
+    if (!bytes) return "UNKNOWN";
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / 1048576).toFixed(1)} MB`;
+  }
+
+  return (
+    <div
+      class="sh-modal-overlay fc-lightbox-overlay"
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Viewing ${filename}`}
+      style="z-index: 200; background: rgba(0,0,0,0.95); display: flex; flex-direction: column;"
+    >
+      {/* Close button */}
+      <button
+        class="fc-lightbox-close"
+        onClick={closeLightbox}
+        type="button"
+        aria-label="Close lightbox"
+        style="position: absolute; top: 8px; right: 12px; z-index: 210; background: none; border: none; color: var(--sh-phosphor); font-size: 1.5rem; cursor: pointer; padding: 8px;"
+      >
+        X
+      </button>
+
+      {/* Counter */}
+      <div
+        class="sh-ansi-dim"
+        style="position: absolute; top: 12px; left: 12px; z-index: 210; font-size: 0.8rem;"
+      >
+        {index + 1} / {photoList.length}
+      </div>
+
+      {/* Main image */}
+      <div style="flex: 1; display: flex; align-items: center; justify-content: center; overflow: hidden; padding: 48px 8px 0;">
+        {photo.is_video ? (
+          <video
+            src={`/media/${filename}`}
+            controls
+            autoplay
+            style="max-width: 100%; max-height: 100%; object-fit: contain;"
+          />
+        ) : (
+          <img
+            src={`/media/${filename}`}
+            alt={filename}
+            style="max-width: 100%; max-height: 100%; object-fit: contain;"
+          />
+        )}
+      </div>
+
+      {/* Navigation arrows (large touch targets) */}
+      {index > 0 && (
+        <button
+          class="fc-lightbox-nav fc-lightbox-nav--prev"
+          onClick={(evt) => { evt.stopPropagation(); navigate(-1); }}
+          type="button"
+          aria-label="Previous photo"
+          style="position: absolute; left: 0; top: 50%; transform: translateY(-50%); background: rgba(0,0,0,0.4); border: none; color: var(--sh-phosphor); font-size: 2rem; padding: 16px 12px; cursor: pointer; z-index: 205;"
+        >
+          &lt;
+        </button>
+      )}
+      {index < photoList.length - 1 && (
+        <button
+          class="fc-lightbox-nav fc-lightbox-nav--next"
+          onClick={(evt) => { evt.stopPropagation(); navigate(1); }}
+          type="button"
+          aria-label="Next photo"
+          style="position: absolute; right: 0; top: 50%; transform: translateY(-50%); background: rgba(0,0,0,0.4); border: none; color: var(--sh-phosphor); font-size: 2rem; padding: 16px 12px; cursor: pointer; z-index: 205;"
+        >
+          &gt;
+        </button>
+      )}
+
+      {/* Bottom action bar */}
+      <div
+        class="fc-lightbox-actions"
+        onClick={(evt) => evt.stopPropagation()}
+        style="display: flex; gap: var(--space-3, 12px); justify-content: center; padding: 12px 16px; background: rgba(0,0,0,0.7); border-top: 1px solid var(--border-subtle, rgba(255,255,255,0.1));"
+      >
+        <button
+          class={`fc-action-btn${photo.is_favorite ? " fc-action-btn--active" : ""}`}
+          onClick={handleFav}
+          type="button"
+          style="background: none; border: 1px solid var(--border-subtle); color: inherit; padding: 8px 14px; cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem;"
+        >
+          [FAV]
+        </button>
+        <button
+          class="fc-action-btn"
+          onClick={toggleInfo}
+          type="button"
+          style="background: none; border: 1px solid var(--border-subtle); color: inherit; padding: 8px 14px; cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem;"
+        >
+          [INFO]
+        </button>
+        <button
+          class="fc-action-btn"
+          onClick={handleDeleteAction}
+          type="button"
+          style="background: none; border: 1px solid var(--border-subtle); color: inherit; padding: 8px 14px; cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem;"
+        >
+          [DELETE]
+        </button>
+      </div>
+
+      {/* Info panel (toggled) */}
+      {infoOpen.value && (
+        <div
+          class="fc-lightbox-info sh-card"
+          onClick={(evt) => evt.stopPropagation()}
+          style="padding: 12px 16px; background: rgba(0,0,0,0.85); border-top: 1px solid var(--border-subtle); font-size: 0.8rem; font-family: var(--font-mono, monospace);"
+        >
+          <div style="display: grid; grid-template-columns: auto 1fr; gap: 4px 16px; margin-bottom: 12px;">
+            <span class="sh-ansi-dim">FILE</span>
+            <span>{filename}</span>
+
+            {photo.exif_date && (
+              <>
+                <span class="sh-ansi-dim">EXIF DATE</span>
+                <span>{photo.exif_date}</span>
+              </>
+            )}
+
+            <span class="sh-ansi-dim">UPLOADED</span>
+            <span>{photo.uploaded_at || "UNKNOWN"}</span>
+
+            <span class="sh-ansi-dim">VIEWS</span>
+            <span>{photo.view_count != null ? photo.view_count : 0}</span>
+
+            <span class="sh-ansi-dim">SIZE</span>
+            <span>{formatSize(photo.file_size)}</span>
+
+            {(photo.width && photo.height) && (
+              <>
+                <span class="sh-ansi-dim">DIMENSIONS</span>
+                <span>{photo.width} x {photo.height}</span>
+              </>
+            )}
+
+            <span class="sh-ansi-dim">UPLOADED BY</span>
+            <span>{photo.uploaded_by || "default"}</span>
+          </div>
+
+          {/* Tags section */}
+          <div style="border-top: 1px solid var(--border-subtle); padding-top: 8px;">
+            <div class="sh-ansi-dim" style="margin-bottom: 6px;">TAGS</div>
+            <div style="display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px;">
+              {(tagSuggestions.value || []).map((tag) => (
+                <span
+                  key={tag.id}
+                  class="sh-filter-chip sh-filter-chip--active"
+                  onClick={() => handleRemoveTag(tag)}
+                  style="cursor: pointer; font-size: 0.75rem;"
+                  title="Click to remove"
+                >
+                  {tag.name} x
+                </span>
+              ))}
+              {(!tagSuggestions.value || tagSuggestions.value.length === 0) && (
+                <span class="sh-ansi-dim" style="font-size: 0.75rem;">NO TAGS</span>
+              )}
+            </div>
+
+            {/* Tag input with autocomplete */}
+            <div style="position: relative;">
+              <input
+                class="sh-input"
+                type="text"
+                placeholder="ADD TAG..."
+                value={tagInput.value}
+                onInput={(evt) => { tagInput.value = evt.target.value; }}
+                onKeyDown={handleTagKeyDown}
+                style="width: 100%; font-size: 0.8rem; padding: 6px 8px;"
+              />
+              {autoSuggestions.length > 0 && (
+                <div
+                  class="sh-card"
+                  style="position: absolute; bottom: 100%; left: 0; right: 0; z-index: 220; margin-bottom: 2px; padding: 4px 0;"
+                >
+                  {autoSuggestions.map((sug) => (
+                    <button
+                      key={sug.id}
+                      class="fc-ctx-item"
+                      type="button"
+                      onClick={() => {
+                        if (onAddTag) onAddTag(photo, sug.name);
+                        tagInput.value = "";
+                        setTimeout(() => {
+                          fetch(`/api/photos/${photo.id}/tags`)
+                            .then((resp) => resp.ok ? resp.json() : [])
+                            .then((data) => { tagSuggestions.value = data; })
+                            .catch(() => {});
+                        }, 300);
+                      }}
+                      style="font-size: 0.75rem;"
+                    >
+                      {sug.name}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/components/PhoneLayout.jsx
+++ b/app/frontend/src/components/PhoneLayout.jsx
@@ -52,8 +52,19 @@ function SystemIcon() {
   );
 }
 
+function AlbumsIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <line x1="3" y1="9" x2="21" y2="9" />
+      <line x1="9" y1="3" x2="9" y2="21" />
+    </svg>
+  );
+}
+
 const navItems = [
   { path: "/", label: "Upload", icon: UploadIcon },
+  { path: "/albums", label: "Albums", icon: AlbumsIcon },
   { path: "/settings", label: "Settings", icon: SettingsIcon },
   { path: "/map", label: "Map", icon: MapIcon },
   { path: "/stats", label: "Stats", icon: StatsIcon },

--- a/app/frontend/src/components/PhotoCard.jsx
+++ b/app/frontend/src/components/PhotoCard.jsx
@@ -1,49 +1,217 @@
-/** @fileoverview PhotoCard — single photo thumbnail card extracted from PhotoGrid. */
+/** @fileoverview PhotoCard — single photo thumbnail card with favorite toggle, selection, long-press context. */
+import { signal } from "@preact/signals";
+import { useRef, useCallback } from "preact/hooks";
+
+/** Context menu state: { photo, x, y } or null. */
+export const contextTarget = signal(null);
+
+/** Long-press threshold in ms. */
+const LONG_PRESS_MS = 500;
 
 /**
- * PhotoCard — displays a single photo/video thumbnail with optional actions.
- *
- * Pure presentational component. Renders identically to the cards
- * previously inline in PhotoGrid's .map() body.
+ * PhotoCard — displays a single photo/video thumbnail with actions.
  *
  * @param {object}   props
  * @param {object}   props.photo            - Photo object from API
- * @param {Function} [props.onDelete]       - Called when card is clicked (opens delete modal)
- * @param {Function} [props.onToggleFavorite] - Called to toggle favorite (future use)
- * @param {Function} [props.onSelect]       - Called when card is selected (future use)
- * @param {boolean}  [props.selected]       - Whether this card is selected (future use)
+ * @param {Function} [props.onDelete]       - Called when delete action invoked
+ * @param {Function} [props.onToggleFavorite] - Called to toggle favorite
+ * @param {Function} [props.onSelect]       - Called when card is selected (tap opens lightbox, etc.)
+ * @param {boolean}  [props.selected]       - Whether this card is selected
+ * @param {boolean}  [props.selectable]     - Whether selection checkbox is shown
+ * @param {Function} [props.onSelectionToggle] - Called when selection checkbox is toggled
+ * @param {Function} [props.onAddToAlbum]   - Called for "add to album" context action
  */
-export function PhotoCard({ photo, onDelete, onToggleFavorite, onSelect, selected }) {
-  function handleClick() {
+export function PhotoCard({
+  photo,
+  onDelete,
+  onToggleFavorite,
+  onSelect,
+  selected,
+  selectable,
+  onSelectionToggle,
+  onAddToAlbum,
+}) {
+  const longPressTimer = useRef(null);
+  const didLongPress = useRef(false);
+
+  function handleClick(evt) {
+    // If long-press just fired, swallow the click
+    if (didLongPress.current) {
+      didLongPress.current = false;
+      return;
+    }
+    // If in selection mode, toggle selection
+    if (selectable && onSelectionToggle) {
+      evt.stopPropagation();
+      onSelectionToggle(photo);
+      return;
+    }
+    // Default: open lightbox / select
     if (onSelect) {
       onSelect(photo);
-    } else if (onDelete) {
-      onDelete(photo);
     }
   }
 
+  function handleFavClick(evt) {
+    evt.stopPropagation();
+    if (onToggleFavorite) onToggleFavorite(photo);
+  }
+
+  function handleCheckboxChange(evt) {
+    evt.stopPropagation();
+    if (onSelectionToggle) onSelectionToggle(photo);
+  }
+
+  // --- Long-press handlers (touch + mouse) ---
+  function startLongPress(evt) {
+    didLongPress.current = false;
+    longPressTimer.current = setTimeout(() => {
+      didLongPress.current = true;
+      const rect = evt.currentTarget.getBoundingClientRect();
+      contextTarget.value = {
+        photo,
+        x: rect.left + rect.width / 2,
+        y: rect.top,
+        onDelete,
+        onToggleFavorite,
+        onAddToAlbum,
+      };
+    }, LONG_PRESS_MS);
+  }
+
+  function cancelLongPress() {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }
+
+  const isFav = photo.is_favorite;
+
   return (
     <div
-      key={photo.name}
-      class={`sh-card sh-clickable${selected ? " sh-card--selected" : ""}`}
+      class={`sh-card sh-clickable${selected ? " sh-card--selected" : ""}${isFav ? " fc-card--favorite" : ""}`}
       onClick={handleClick}
+      onTouchStart={startLongPress}
+      onTouchEnd={cancelLongPress}
+      onTouchCancel={cancelLongPress}
+      onMouseDown={startLongPress}
+      onMouseUp={cancelLongPress}
+      onMouseLeave={cancelLongPress}
       role="button"
       tabIndex={0}
-      aria-label={`${photo.name} — click to ${onSelect ? "select" : "delete"}`}
+      aria-label={`${photo.name || photo.filename} — ${isFav ? "favorite" : "photo"}`}
+      style="position: relative;"
     >
+      {/* Selection checkbox */}
+      {selectable && (
+        <label
+          class="fc-select-check"
+          onClick={(evt) => evt.stopPropagation()}
+          style="position: absolute; top: 4px; left: 4px; z-index: 2; cursor: pointer;"
+        >
+          <input
+            type="checkbox"
+            checked={!!selected}
+            onChange={handleCheckboxChange}
+            aria-label={`Select ${photo.name || photo.filename}`}
+            style="width: 18px; height: 18px; accent-color: var(--sh-phosphor);"
+          />
+        </label>
+      )}
+
+      {/* Favorite toggle */}
+      <button
+        class={`fc-fav-btn${isFav ? " fc-fav-btn--active" : ""}`}
+        onClick={handleFavClick}
+        aria-label={isFav ? "Remove from favorites" : "Add to favorites"}
+        aria-pressed={!!isFav}
+        type="button"
+        style={`
+          position: absolute; top: 4px; right: 4px; z-index: 2;
+          background: rgba(0,0,0,0.6); border: none; cursor: pointer;
+          color: ${isFav ? "gold" : "rgba(255,255,255,0.5)"};
+          font-size: 1rem; padding: 2px 4px; line-height: 1;
+          border-radius: 2px;
+        `}
+      >
+        {isFav ? "\u2605" : "\u2606"}
+      </button>
+
       <img
-        src={photo.is_video ? `/thumbnail/${photo.name}` : `/media/${photo.name}`}
-        alt={photo.name}
+        src={photo.is_video ? `/thumbnail/${photo.name || photo.filename}` : `/media/${photo.name || photo.filename}`}
+        alt={photo.name || photo.filename}
         loading="lazy"
         style="width: 100%; aspect-ratio: 1; object-fit: cover; display: block; border-radius: 4px;"
       />
       {photo.is_video && (
-        <span class="sh-status-badge" data-sh-status="active" style="position: absolute; top: 6px; right: 6px;">
+        <span class="sh-status-badge" data-sh-status="active" style="position: absolute; top: 6px; right: 6px; margin-top: 22px;">
           VIDEO
         </span>
       )}
       <div class="sh-ansi-dim" style="padding: 6px 0 0; font-size: 0.75rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
-        {photo.name}
+        {photo.name || photo.filename}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * ContextMenu — rendered once, positioned at contextTarget location.
+ * Dismiss by clicking outside or selecting an action.
+ */
+export function ContextMenu() {
+  const ctx = contextTarget.value;
+  if (!ctx) return null;
+
+  function dismiss() {
+    contextTarget.value = null;
+  }
+
+  function doFavorite() {
+    if (ctx.onToggleFavorite) ctx.onToggleFavorite(ctx.photo);
+    dismiss();
+  }
+
+  function doAlbum() {
+    if (ctx.onAddToAlbum) ctx.onAddToAlbum(ctx.photo);
+    dismiss();
+  }
+
+  function doDelete() {
+    if (ctx.onDelete) ctx.onDelete(ctx.photo);
+    dismiss();
+  }
+
+  return (
+    <div
+      class="sh-modal-overlay"
+      onClick={dismiss}
+      style="z-index: 100; background: rgba(0,0,0,0.4);"
+    >
+      <div
+        class="sh-card fc-context-menu"
+        style={`
+          position: fixed;
+          left: ${Math.max(8, ctx.x - 80)}px;
+          top: ${Math.max(8, ctx.y - 10)}px;
+          z-index: 101;
+          min-width: 160px;
+          padding: 4px 0;
+        `}
+        onClick={(evt) => evt.stopPropagation()}
+      >
+        <button class="fc-ctx-item" onClick={doFavorite} type="button">
+          [FAV] {ctx.photo.is_favorite ? "UNFAVORITE" : "FAVORITE"}
+        </button>
+        {ctx.onAddToAlbum && (
+          <button class="fc-ctx-item" onClick={doAlbum} type="button">
+            [ADD] TO ALBUM
+          </button>
+        )}
+        <button class="fc-ctx-item fc-ctx-item--danger" onClick={doDelete} type="button">
+          [DELETE] REMOVE
+        </button>
       </div>
     </div>
   );

--- a/app/frontend/src/components/PhotoGrid.jsx
+++ b/app/frontend/src/components/PhotoGrid.jsx
@@ -13,8 +13,10 @@ const deleting = signal(false);
  * @param {object}   props
  * @param {Array}    props.photos   - Array of photo objects from /api/photos
  * @param {Function} [props.onDelete] - Called with filename after successful delete
+ * @param {Function} [props.onToggleFavorite] - Called to toggle favorite on a photo
+ * @param {Function} [props.onSelect] - Called when a photo is tapped (opens lightbox)
  */
-export function PhotoGrid({ photos = [], onDelete }) {
+export function PhotoGrid({ photos = [], onDelete, onToggleFavorite, onSelect }) {
   function openDeleteModal(photo) {
     deleteTarget.value = photo;
   }
@@ -30,12 +32,12 @@ export function PhotoGrid({ photos = [], onDelete }) {
     deleting.value = true;
 
     const form = new FormData();
-    form.append("filename", photo.name);
+    form.append("filename", photo.name || photo.filename);
 
     fetch("/delete", { method: "POST", body: form })
       .then((resp) => {
         if (resp.ok || resp.redirected) {
-          onDelete?.(photo.name);
+          onDelete?.(photo.name || photo.filename);
         }
       })
       .catch((err) => {
@@ -55,7 +57,7 @@ export function PhotoGrid({ photos = [], onDelete }) {
     return (
       <div class="sh-frame" data-label="MEDIA">
         <div style="padding: 32px; text-align: center;">
-          <div class="sh-ansi-dim">NO ACTIVE PHOTOS</div>
+          <div class="sh-ansi-dim">NO DATA</div>
         </div>
       </div>
     );
@@ -66,9 +68,11 @@ export function PhotoGrid({ photos = [], onDelete }) {
       <div class="sh-grid sh-grid-3">
         {photos.map((photo) => (
           <PhotoCard
-            key={photo.name}
+            key={photo.name || photo.id}
             photo={photo}
             onDelete={openDeleteModal}
+            onToggleFavorite={onToggleFavorite}
+            onSelect={onSelect}
           />
         ))}
       </div>
@@ -76,7 +80,7 @@ export function PhotoGrid({ photos = [], onDelete }) {
       <ShModal
         open={!!target}
         title="CONFIRM: DELETE FILE"
-        body={target ? `Remove "${target.name}" (${target.size_human})? This cannot be undone.` : ""}
+        body={target ? `Remove "${target.name || target.filename}" (${target.size_human || ""})? This cannot be undone.` : ""}
         confirmLabel={isDeleting ? "DELETING..." : "DELETE"}
         cancelLabel="CANCEL"
         onConfirm={confirmDelete}

--- a/app/frontend/src/pages/Albums.jsx
+++ b/app/frontend/src/pages/Albums.jsx
@@ -1,0 +1,413 @@
+/** @fileoverview Albums page — album management with smart albums, create/delete, photo grid. */
+import { signal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+import { ShModal } from "superhot-ui/preact";
+import { PhotoGrid } from "../components/PhotoGrid.jsx";
+import { PhotoCard } from "../components/PhotoCard.jsx";
+import { Lightbox, openLightbox } from "../components/Lightbox.jsx";
+
+/** Reactive state */
+const albums = signal([]);
+const loading = signal(true);
+const selectedAlbum = signal(null);
+const albumPhotos = signal([]);
+const albumPhotosLoading = signal(false);
+
+/** Create modal state */
+const createOpen = signal(false);
+const createName = signal("");
+const createDesc = signal("");
+const creating = signal(false);
+
+/** Delete modal state */
+const deleteTarget = signal(null);
+const deleting = signal(false);
+
+/** Filter: 'all' | 'smart' | 'user' */
+const albumFilter = signal("all");
+
+// ---------------------------------------------------------------------------
+// Data fetching
+// ---------------------------------------------------------------------------
+
+function fetchAlbums() {
+  return fetch("/api/albums")
+    .then((resp) => resp.json())
+    .then((data) => {
+      albums.value = data;
+    })
+    .catch((err) => {
+      console.warn("Albums: fetchAlbums failed", err);
+    });
+}
+
+function fetchAlbumPhotos(albumId) {
+  albumPhotosLoading.value = true;
+  const isSmart = String(albumId).startsWith("smart:");
+
+  let url;
+  if (isSmart) {
+    const key = albumId.replace("smart:", "");
+    url = `/api/albums/smart/${key}/photos`;
+  } else {
+    url = `/api/albums/${albumId}/photos`;
+  }
+
+  return fetch(url)
+    .then((resp) => resp.json())
+    .then((data) => {
+      // Augment with name field for PhotoCard compatibility
+      for (const photo of data) {
+        photo.name = photo.name || photo.filename;
+        photo.size_human = photo.size_human || "";
+      }
+      albumPhotos.value = data;
+    })
+    .catch((err) => {
+      console.warn("Albums: fetchAlbumPhotos failed", err);
+      albumPhotos.value = [];
+    })
+    .finally(() => {
+      albumPhotosLoading.value = false;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+function handleCreateAlbum() {
+  const name = createName.value.trim();
+  if (!name || creating.value) return;
+
+  creating.value = true;
+  fetch("/api/albums", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, description: createDesc.value.trim() || null }),
+  })
+    .then((resp) => {
+      if (resp.ok) {
+        createOpen.value = false;
+        createName.value = "";
+        createDesc.value = "";
+        fetchAlbums();
+      } else {
+        return resp.json().then((data) => {
+          console.warn("Create album failed:", data.error);
+        });
+      }
+    })
+    .catch((err) => console.warn("Create album error:", err))
+    .finally(() => { creating.value = false; });
+}
+
+function handleDeleteAlbum() {
+  const album = deleteTarget.value;
+  if (!album || deleting.value) return;
+
+  deleting.value = true;
+  fetch(`/api/albums/${album.id}`, { method: "DELETE" })
+    .then(() => {
+      deleteTarget.value = null;
+      if (selectedAlbum.value && selectedAlbum.value.id === album.id) {
+        selectedAlbum.value = null;
+        albumPhotos.value = [];
+      }
+      fetchAlbums();
+    })
+    .catch((err) => console.warn("Delete album error:", err))
+    .finally(() => { deleting.value = false; });
+}
+
+function handleToggleFavorite(photo) {
+  fetch(`/api/photos/${photo.id}/favorite`, { method: "POST" })
+    .then((resp) => resp.json())
+    .then(() => {
+      if (selectedAlbum.value) fetchAlbumPhotos(selectedAlbum.value.id);
+    })
+    .catch((err) => console.warn("Favorite toggle error:", err));
+}
+
+function handlePhotoSelect(photo) {
+  const photoList = albumPhotos.value;
+  const idx = photoList.findIndex((p) => p.id === photo.id);
+  openLightbox(photoList, idx >= 0 ? idx : 0);
+}
+
+function handleAddTag(photo, tagName) {
+  fetch(`/api/photos/${photo.id}/tags`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: tagName }),
+  }).catch((err) => console.warn("Add tag error:", err));
+}
+
+function handleRemoveTag(photo, tag) {
+  fetch(`/api/photos/${photo.id}/tags/${tag.id}`, { method: "DELETE" })
+    .catch((err) => console.warn("Remove tag error:", err));
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function Albums() {
+  useEffect(() => {
+    fetchAlbums().then(() => { loading.value = false; });
+  }, []);
+
+  const isLoading = loading.value;
+  const allAlbums = albums.value;
+  const currentAlbum = selectedAlbum.value;
+  const currentFilter = albumFilter.value;
+
+  // Filter albums
+  const filteredAlbums = allAlbums.filter((album) => {
+    if (currentFilter === "smart") return album.smart;
+    if (currentFilter === "user") return !album.smart;
+    return true;
+  });
+
+  // Separate smart and user albums for display order (smart first)
+  const smartAlbums = filteredAlbums.filter((a) => a.smart);
+  const userAlbums = filteredAlbums.filter((a) => !a.smart);
+  const orderedAlbums = [...smartAlbums, ...userAlbums];
+
+  if (isLoading) {
+    return (
+      <div class="sh-frame" style="padding: 24px; text-align: center;">
+        <div class="sh-ansi-dim">STANDBY</div>
+      </div>
+    );
+  }
+
+  // --- Album detail view ---
+  if (currentAlbum) {
+    return (
+      <div class="sh-animate-page-enter fc-page">
+        <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 8px;">
+          <button
+            class="fc-action-btn"
+            onClick={() => { selectedAlbum.value = null; albumPhotos.value = []; }}
+            type="button"
+            style="background: none; border: 1px solid var(--border-subtle); color: var(--sh-phosphor); padding: 6px 12px; cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem;"
+          >
+            BACK
+          </button>
+          <span style="font-family: var(--font-mono, monospace); font-size: 1rem; font-weight: 700;">
+            {currentAlbum.name}
+          </span>
+          {currentAlbum.smart && (
+            <span class="sh-status-badge" data-sh-status="active" style="font-size: 0.65rem;">SMART</span>
+          )}
+        </div>
+
+        {albumPhotosLoading.value ? (
+          <div class="sh-frame" style="padding: 24px; text-align: center;">
+            <div class="sh-ansi-dim">STANDBY</div>
+          </div>
+        ) : albumPhotos.value.length === 0 ? (
+          <div class="sh-frame" data-label="PHOTOS">
+            <div style="padding: 32px; text-align: center;">
+              <div class="sh-ansi-dim">NO DATA</div>
+            </div>
+          </div>
+        ) : (
+          <div class="sh-grid sh-grid-3">
+            {albumPhotos.value.map((photo) => (
+              <PhotoCard
+                key={photo.id}
+                photo={photo}
+                onSelect={handlePhotoSelect}
+                onToggleFavorite={handleToggleFavorite}
+              />
+            ))}
+          </div>
+        )}
+
+        {!currentAlbum.smart && (
+          <div style="margin-top: 12px;">
+            <button
+              class="fc-action-btn fc-action-btn--danger"
+              onClick={() => { deleteTarget.value = currentAlbum; }}
+              type="button"
+              style="background: none; border: 1px solid var(--sh-threat, #ff4444); color: var(--sh-threat, #ff4444); padding: 8px 14px; cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem;"
+            >
+              [DELETE] ALBUM
+            </button>
+          </div>
+        )}
+
+        {/* Delete album modal */}
+        <ShModal
+          open={!!deleteTarget.value}
+          title="CONFIRM: DELETE ALBUM?"
+          body="PHOTOS PRESERVED. Only the album grouping will be removed."
+          confirmLabel={deleting.value ? "DELETING..." : "DELETE"}
+          cancelLabel="CANCEL"
+          onConfirm={handleDeleteAlbum}
+          onCancel={() => { deleteTarget.value = null; }}
+        />
+
+        {/* Lightbox */}
+        <Lightbox
+          onToggleFavorite={handleToggleFavorite}
+          onAddTag={handleAddTag}
+          onRemoveTag={handleRemoveTag}
+        />
+      </div>
+    );
+  }
+
+  // --- Album grid view ---
+  return (
+    <div class="sh-animate-page-enter fc-page">
+      {/* Header + create button */}
+      <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px;">
+        <span style="font-family: var(--font-mono, monospace); font-size: 1rem; font-weight: 700;">
+          ALBUMS
+        </span>
+        <button
+          class="fc-action-btn"
+          onClick={() => { createOpen.value = true; }}
+          type="button"
+          style="background: none; border: 1px solid var(--sh-phosphor); color: var(--sh-phosphor); padding: 6px 12px; cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem;"
+        >
+          [ADD] CREATE ALBUM
+        </button>
+      </div>
+
+      {/* Filter chips */}
+      <div class="sh-filter-panel" style="display: flex; gap: 8px; margin-bottom: 12px; flex-wrap: wrap;">
+        {["all", "smart", "user"].map((filterKey) => (
+          <span
+            key={filterKey}
+            class={`sh-filter-chip${currentFilter === filterKey ? " sh-filter-chip--active" : ""}`}
+            onClick={() => { albumFilter.value = filterKey; }}
+            style="cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem; padding: 4px 10px;"
+          >
+            {filterKey.toUpperCase()}
+          </span>
+        ))}
+      </div>
+
+      {/* Album cards grid */}
+      {orderedAlbums.length === 0 ? (
+        <div class="sh-frame" data-label="ALBUMS">
+          <div style="padding: 32px; text-align: center;">
+            <div class="sh-ansi-dim">NO DATA</div>
+          </div>
+        </div>
+      ) : (
+        <div class="sh-grid sh-grid-3">
+          {orderedAlbums.map((album) => (
+            <div
+              key={album.id}
+              class="sh-card sh-clickable"
+              onClick={() => {
+                selectedAlbum.value = album;
+                fetchAlbumPhotos(album.id);
+              }}
+              role="button"
+              tabIndex={0}
+              aria-label={`Album: ${album.name}`}
+              style="position: relative; overflow: hidden;"
+            >
+              {/* Cover image or placeholder */}
+              {album.cover_photo_id ? (
+                <div style="width: 100%; aspect-ratio: 1; background: var(--surface-void, #111); display: flex; align-items: center; justify-content: center; overflow: hidden; border-radius: 4px;">
+                  <img
+                    src={`/media/${album.cover_filename || ""}`}
+                    alt=""
+                    loading="lazy"
+                    style="width: 100%; height: 100%; object-fit: cover;"
+                    onError={(evt) => { evt.target.style.display = "none"; }}
+                  />
+                </div>
+              ) : (
+                <div style="width: 100%; aspect-ratio: 1; background: var(--surface-void, #111); display: flex; align-items: center; justify-content: center; border-radius: 4px;">
+                  <span class="sh-ansi-dim" style="font-size: 2rem;">
+                    {album.smart ? "SYS" : "USR"}
+                  </span>
+                </div>
+              )}
+
+              {/* Album info */}
+              <div style="padding: 6px 0 0;">
+                <div style="display: flex; align-items: center; gap: 6px;">
+                  <span style="font-family: var(--font-mono, monospace); font-size: 0.8rem; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                    {album.name}
+                  </span>
+                  {album.smart && (
+                    <span class="sh-status-badge" data-sh-status="active" style="font-size: 0.55rem;">SMART</span>
+                  )}
+                </div>
+                <div class="sh-ansi-dim" style="font-size: 0.7rem;">
+                  {album.photo_count != null ? album.photo_count : "?"} PHOTOS
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Create album modal */}
+      {createOpen.value && (
+        <div
+          class="sh-modal-overlay"
+          onClick={(evt) => { if (evt.target === evt.currentTarget) createOpen.value = false; }}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Create album"
+        >
+          <div class="sh-modal" onClick={(evt) => evt.stopPropagation()}>
+            <div class="sh-modal-title">CREATE ALBUM</div>
+            <div class="sh-modal-body" style="display: flex; flex-direction: column; gap: 12px;">
+              <div>
+                <label class="sh-ansi-dim" style="font-size: 0.75rem; display: block; margin-bottom: 4px;">NAME</label>
+                <input
+                  class="sh-input"
+                  type="text"
+                  value={createName.value}
+                  onInput={(evt) => { createName.value = evt.target.value; }}
+                  placeholder="Album name"
+                  style="width: 100%; font-size: 0.9rem; padding: 8px;"
+                  autofocus
+                />
+              </div>
+              <div>
+                <label class="sh-ansi-dim" style="font-size: 0.75rem; display: block; margin-bottom: 4px;">DESCRIPTION</label>
+                <input
+                  class="sh-input"
+                  type="text"
+                  value={createDesc.value}
+                  onInput={(evt) => { createDesc.value = evt.target.value; }}
+                  placeholder="Optional"
+                  style="width: 100%; font-size: 0.9rem; padding: 8px;"
+                />
+              </div>
+            </div>
+            <div class="sh-modal-actions">
+              <button
+                class="sh-modal-action"
+                onClick={() => { createOpen.value = false; createName.value = ""; createDesc.value = ""; }}
+                type="button"
+              >
+                [CANCEL]
+              </button>
+              <button
+                class="sh-modal-action sh-modal-action--confirm"
+                onClick={handleCreateAlbum}
+                disabled={creating.value || !createName.value.trim()}
+                type="button"
+              >
+                [{creating.value ? "CREATING..." : "CONFIRM"}]
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/pages/Upload.jsx
+++ b/app/frontend/src/pages/Upload.jsx
@@ -1,4 +1,4 @@
-/** @fileoverview Upload page — dropzone + batch progress + photo grid + storage + user filter.
+/** @fileoverview Upload page — dropzone + batch progress + filter bar + photo grid + lightbox + storage + user filter.
  *
  * Batch upload shows per-file status, auto-retries failed uploads (3 attempts,
  * exponential backoff), and displays a completion summary.
@@ -11,6 +11,8 @@ import { applyThreshold } from "superhot-ui";
 import { ShDropzone } from "../components/ShDropzone.jsx";
 import { PhotoGrid } from "../components/PhotoGrid.jsx";
 import { OfflineBanner } from "../components/OfflineBanner.jsx";
+import { ContextMenu } from "../components/PhotoCard.jsx";
+import { Lightbox, openLightbox } from "../components/Lightbox.jsx";
 import { createSSE } from "../lib/sse.js";
 import { fetchWithTimeout } from "../lib/fetch.js";
 import {
@@ -23,17 +25,36 @@ import {
 const photos = signal([]);
 const disk = signal({ percent: 0, used: "\u2014", total: "\u2014", free: "\u2014" });
 const loading = signal(true);
+const filter = signal("all");
 const userFilter = signal("all");
 const availableUsers = signal([]);
 
 const MAX_RETRIES = 3;
 const RETRY_BASE_MS = 1000;
 
-/** Fetch photos list from API. */
+/** Build ASCII storage bar: [|||...] */
+function storageBar(pct) {
+  const width = 20;
+  const filled = Math.round((pct / 100) * width);
+  const empty = width - filled;
+  return "[" + "\u2593".repeat(filled) + "\u2591".repeat(empty) + "]";
+}
+
+/** Fetch photos list from API with optional filter. */
 function fetchPhotos() {
-  return fetchWithTimeout("/api/photos")
+  const currentFilter = filter.value;
+  let url = "/api/photos";
+  if (currentFilter === "favorites") url += "?filter=favorites";
+  else if (currentFilter === "hidden") url += "?filter=hidden";
+
+  return fetchWithTimeout(url)
     .then((resp) => resp.json())
     .then((data) => {
+      // Ensure name field exists for PhotoCard compatibility
+      for (const photo of data) {
+        photo.name = photo.name || photo.filename;
+        photo.size_human = photo.size_human || "";
+      }
       photos.value = data;
       // Extract unique uploaders for filter dropdown
       const uploaders = [...new Set(data.map((p) => p.uploaded_by).filter(Boolean))];
@@ -54,6 +75,32 @@ function fetchStatus() {
     .catch((err) => {
       console.warn("Upload: fetchStatus fault", err);
     });
+}
+
+function handleToggleFavorite(photo) {
+  fetch(`/api/photos/${photo.id}/favorite`, { method: "POST" })
+    .then((resp) => resp.json())
+    .then(() => fetchPhotos())
+    .catch((err) => console.warn("Favorite toggle error:", err));
+}
+
+function handlePhotoSelect(photo) {
+  const photoList = photos.value;
+  const idx = photoList.findIndex((p) => p.id === photo.id);
+  openLightbox(photoList, idx >= 0 ? idx : 0);
+}
+
+function handleAddTag(photo, tagName) {
+  fetch(`/api/photos/${photo.id}/tags`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: tagName }),
+  }).catch((err) => console.warn("Add tag error:", err));
+}
+
+function handleRemoveTag(photo, tag) {
+  fetch(`/api/photos/${photo.id}/tags/${tag.id}`, { method: "DELETE" })
+    .catch((err) => console.warn("Remove tag error:", err));
 }
 
 /**
@@ -116,7 +163,7 @@ function uploadFileWithRetry(file, onProgress, attempt = 0) {
 
 /**
  * Upload — main upload page.
- * Combines ShDropzone, batch upload progress, PhotoGrid, disk space display, and user filter.
+ * Combines ShDropzone, batch upload progress, filter bar, PhotoGrid, Lightbox, disk space display, and user filter.
  * Prompts "WHO IS UPLOADING?" on first upload if no cookie set.
  * Subscribes to SSE for real-time photo:added/photo:deleted events.
  */
@@ -156,6 +203,11 @@ export function Upload() {
       applyThreshold(storageBarRef.current, disk.value.percent || 0);
     }
   }, [disk.value]);
+
+  // Re-fetch when filter changes
+  useEffect(() => {
+    if (!loading.value) fetchPhotos();
+  }, [filter.value]);
 
   /** Handle batch file selection from dropzone. */
   const handleBatchUpload = useCallback(async (fileList) => {
@@ -237,6 +289,7 @@ export function Upload() {
   const diskPct = currentDisk.percent || 0;
   const isLowDisk = diskPct >= 90;
   const isUploadBlocked = diskPct >= 95;
+  const currentFilter = filter.value;
 
   // Apply user filter
   const allPhotos = photos.value;
@@ -384,8 +437,49 @@ export function Upload() {
         </div>
       )}
 
+      {/* Filter bar */}
+      <div class="sh-filter-panel" style="display: flex; gap: 8px; flex-wrap: wrap;">
+        <span
+          class={`sh-filter-chip${currentFilter === "all" ? " sh-filter-chip--active" : ""}`}
+          onClick={() => { filter.value = "all"; }}
+          style="cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem; padding: 4px 10px;"
+        >
+          ALL
+        </span>
+        <span
+          class={`sh-filter-chip${currentFilter === "favorites" ? " sh-filter-chip--active" : ""}`}
+          onClick={() => { filter.value = "favorites"; }}
+          style="cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem; padding: 4px 10px;"
+        >
+          FAVORITES
+        </span>
+        <span
+          class={`sh-filter-chip${currentFilter === "hidden" ? " sh-filter-chip--active" : ""}`}
+          onClick={() => { filter.value = "hidden"; }}
+          style="cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem; padding: 4px 10px;"
+        >
+          HIDDEN
+        </span>
+      </div>
+
       {/* Photo grid */}
-      <PhotoGrid photos={filteredPhotos} onDelete={handleDelete} />
+      <PhotoGrid
+        photos={filteredPhotos}
+        onDelete={handleDelete}
+        onToggleFavorite={handleToggleFavorite}
+        onSelect={handlePhotoSelect}
+      />
+
+      {/* Context menu (long-press) */}
+      <ContextMenu />
+
+      {/* Lightbox */}
+      <Lightbox
+        onToggleFavorite={handleToggleFavorite}
+        onDelete={handleDelete}
+        onAddTag={handleAddTag}
+        onRemoveTag={handleRemoveTag}
+      />
 
       {/* Toast */}
       {toast && (

--- a/app/modules/db.py
+++ b/app/modules/db.py
@@ -404,10 +404,13 @@ def create_album(name, description=None):
 
 
 def get_albums():
-    """Return all albums as a list of dicts."""
+    """Return all albums as a list of dicts, including photo_count."""
     with closing(get_db()) as conn:
         rows = conn.execute(
-            "SELECT * FROM albums ORDER BY sort_order, name"
+            """SELECT a.*,
+                      (SELECT COUNT(*) FROM album_photos ap WHERE ap.album_id = a.id) AS photo_count
+               FROM albums a
+               ORDER BY a.sort_order, a.name"""
         ).fetchall()
         return [dict(r) for r in rows]
 
@@ -505,6 +508,15 @@ def get_tags(photo_id):
                WHERE pt.photo_id = ?
                ORDER BY t.name""",
             (photo_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def get_all_tags():
+    """Return all tags in the system (for autocomplete)."""
+    with closing(get_db()) as conn:
+        rows = conn.execute(
+            "SELECT id, name FROM tags ORDER BY name"
         ).fetchall()
         return [dict(r) for r in rows]
 

--- a/tests/test_albums.py
+++ b/tests/test_albums.py
@@ -1,0 +1,311 @@
+"""Tests for favorites, albums, tags, and smart album API endpoints.
+
+Covers: favorite toggle, album CRUD, smart album queries, tag CRUD,
+photo filter parameter, and get_all_tags autocomplete.
+"""
+
+from contextlib import closing
+from unittest import mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Favorite toggle tests
+# ---------------------------------------------------------------------------
+
+
+class TestFavoriteToggleAPI:
+    """Tests for the POST /api/photos/<id>/favorite endpoint logic."""
+
+    def test_toggle_favorite_on(self, initialized_db):
+        """Toggling favorite on returns is_favorite=True."""
+        pid = initialized_db.insert_photo(
+            filename="fav_on.jpg", filepath="/media/fav_on.jpg"
+        )
+        result = initialized_db.toggle_favorite(pid)
+        assert result is True
+
+        photo = initialized_db.get_photo_by_id(pid)
+        assert photo["is_favorite"] == 1
+
+    def test_toggle_favorite_off(self, initialized_db):
+        """Toggling favorite twice returns is_favorite=False."""
+        pid = initialized_db.insert_photo(
+            filename="fav_off.jpg", filepath="/media/fav_off.jpg"
+        )
+        initialized_db.toggle_favorite(pid)  # on
+        result = initialized_db.toggle_favorite(pid)  # off
+        assert result is False
+
+    def test_toggle_favorite_nonexistent(self, initialized_db):
+        """Toggling favorite on non-existent photo returns None."""
+        result = initialized_db.toggle_favorite(99999)
+        assert result is None
+
+    def test_favorite_filter(self, initialized_db):
+        """get_photos with favorite_only returns only favorited photos."""
+        p1 = initialized_db.insert_photo(
+            filename="fav_filter1.jpg", filepath="/media/fav_filter1.jpg"
+        )
+        initialized_db.insert_photo(
+            filename="fav_filter2.jpg", filepath="/media/fav_filter2.jpg"
+        )
+        initialized_db.toggle_favorite(p1)
+
+        favs = initialized_db.get_photos(favorite_only=True)
+        assert len(favs) == 1
+        assert favs[0]["filename"] == "fav_filter1.jpg"
+
+    def test_hidden_filter(self, initialized_db):
+        """get_photos with include_hidden returns hidden photos."""
+        pid = initialized_db.insert_photo(
+            filename="hidden.jpg", filepath="/media/hidden.jpg"
+        )
+        initialized_db.toggle_hidden(pid)
+
+        # Default excludes hidden
+        default = initialized_db.get_photos()
+        assert all(p["filename"] != "hidden.jpg" for p in default)
+
+        # With include_hidden
+        hidden = initialized_db.get_photos(include_hidden=True)
+        names = [p["filename"] for p in hidden]
+        assert "hidden.jpg" in names
+
+
+# ---------------------------------------------------------------------------
+# Album CRUD API tests
+# ---------------------------------------------------------------------------
+
+
+class TestAlbumCrudAPI:
+    """Tests for album creation, listing, photo management, and deletion."""
+
+    def test_create_album(self, initialized_db):
+        """Creating an album returns a valid id."""
+        aid = initialized_db.create_album("Test Album", "A test description")
+        assert aid is not None
+        assert aid > 0
+
+    def test_create_duplicate_album_raises(self, initialized_db):
+        """Creating an album with a duplicate name raises an error."""
+        initialized_db.create_album("Unique")
+        with pytest.raises(Exception, match="UNIQUE"):
+            initialized_db.create_album("Unique")
+
+    def test_list_albums_includes_photo_count(self, initialized_db):
+        """get_albums returns photo_count for each album."""
+        aid = initialized_db.create_album("Counted")
+        p1 = initialized_db.insert_photo(
+            filename="count1.jpg", filepath="/media/count1.jpg"
+        )
+        p2 = initialized_db.insert_photo(
+            filename="count2.jpg", filepath="/media/count2.jpg"
+        )
+        initialized_db.add_to_album(p1, aid)
+        initialized_db.add_to_album(p2, aid)
+
+        albums = initialized_db.get_albums()
+        counted = [a for a in albums if a["name"] == "Counted"][0]
+        assert counted["photo_count"] == 2
+
+    def test_album_photos_listing(self, initialized_db):
+        """get_album_photos returns all photos in an album."""
+        aid = initialized_db.create_album("Listed")
+        pid = initialized_db.insert_photo(
+            filename="listed.jpg", filepath="/media/listed.jpg"
+        )
+        initialized_db.add_to_album(pid, aid)
+
+        photos = initialized_db.get_album_photos(aid)
+        assert len(photos) == 1
+        assert photos[0]["filename"] == "listed.jpg"
+
+    def test_remove_photo_from_album(self, initialized_db):
+        """Removing a photo from an album reduces the count."""
+        aid = initialized_db.create_album("Remove")
+        pid = initialized_db.insert_photo(
+            filename="removable.jpg", filepath="/media/removable.jpg"
+        )
+        initialized_db.add_to_album(pid, aid)
+        initialized_db.remove_from_album(pid, aid)
+
+        photos = initialized_db.get_album_photos(aid)
+        assert len(photos) == 0
+
+    def test_delete_album_preserves_photos(self, initialized_db):
+        """Deleting an album does not delete the photos themselves."""
+        aid = initialized_db.create_album("Deleteable")
+        pid = initialized_db.insert_photo(
+            filename="preserved.jpg", filepath="/media/preserved.jpg"
+        )
+        initialized_db.add_to_album(pid, aid)
+        initialized_db.delete_album(aid)
+
+        # Photo still exists
+        photo = initialized_db.get_photo_by_id(pid)
+        assert photo is not None
+        assert photo["quarantined"] == 0
+
+    def test_delete_album_cascades_album_photos(self, initialized_db):
+        """Deleting an album removes entries from album_photos."""
+        aid = initialized_db.create_album("CascadeTest")
+        pid = initialized_db.insert_photo(
+            filename="cascade.jpg", filepath="/media/cascade.jpg"
+        )
+        initialized_db.add_to_album(pid, aid)
+        initialized_db.delete_album(aid)
+
+        with closing(initialized_db.get_db()) as conn:
+            count = conn.execute(
+                "SELECT COUNT(*) AS c FROM album_photos WHERE album_id = ?",
+                (aid,),
+            ).fetchone()["c"]
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Smart album tests
+# ---------------------------------------------------------------------------
+
+
+class TestSmartAlbumsAPI:
+    """Tests for smart album computed queries."""
+
+    def test_recent_returns_new_photos(self, initialized_db):
+        """RECENT smart album includes recently uploaded photos."""
+        initialized_db.insert_photo(
+            filename="smart_recent.jpg", filepath="/media/smart_recent.jpg"
+        )
+        photos = initialized_db.get_smart_album_photos("recent")
+        names = [p["filename"] for p in photos]
+        assert "smart_recent.jpg" in names
+
+    def test_most_shown_ordered_by_views(self, initialized_db):
+        """MOST SHOWN smart album orders by view_count descending."""
+        p1 = initialized_db.insert_photo(
+            filename="views_high.jpg", filepath="/media/views_high.jpg"
+        )
+        p2 = initialized_db.insert_photo(
+            filename="views_low.jpg", filepath="/media/views_low.jpg"
+        )
+        # Set view counts directly
+        with initialized_db._write_lock:
+            with closing(initialized_db.get_db()) as conn:
+                conn.execute("UPDATE photos SET view_count = 50 WHERE id = ?", (p1,))
+                conn.execute("UPDATE photos SET view_count = 5 WHERE id = ?", (p2,))
+                conn.commit()
+
+        photos = initialized_db.get_smart_album_photos("most_shown")
+        assert len(photos) >= 2
+        assert photos[0]["filename"] == "views_high.jpg"
+        assert photos[1]["filename"] == "views_low.jpg"
+
+    def test_unknown_smart_album_empty(self, initialized_db):
+        """Unknown smart album key returns empty list."""
+        photos = initialized_db.get_smart_album_photos("nonexistent_key")
+        assert photos == []
+
+    def test_smart_albums_exclude_quarantined(self, initialized_db):
+        """Smart albums do not include quarantined photos."""
+        initialized_db.insert_photo(
+            filename="quarantined.jpg", filepath="/media/quarantined.jpg",
+            quarantined=True, quarantine_reason="test",
+        )
+        for key in ("recent", "most_shown"):
+            photos = initialized_db.get_smart_album_photos(key)
+            names = [p["filename"] for p in photos]
+            assert "quarantined.jpg" not in names
+
+
+# ---------------------------------------------------------------------------
+# Tag CRUD API tests
+# ---------------------------------------------------------------------------
+
+
+class TestTagCrudAPI:
+    """Tests for tag add, remove, list, and autocomplete."""
+
+    def test_add_tag(self, initialized_db):
+        """Adding a tag returns a valid tag id."""
+        pid = initialized_db.insert_photo(
+            filename="tag_add.jpg", filepath="/media/tag_add.jpg"
+        )
+        tag_id = initialized_db.add_tag(pid, "landscape")
+        assert tag_id is not None
+        assert tag_id > 0
+
+    def test_list_photo_tags(self, initialized_db):
+        """get_tags returns tags for a specific photo."""
+        pid = initialized_db.insert_photo(
+            filename="tag_list.jpg", filepath="/media/tag_list.jpg"
+        )
+        initialized_db.add_tag(pid, "sunset")
+        initialized_db.add_tag(pid, "ocean")
+
+        tags = initialized_db.get_tags(pid)
+        names = [t["name"] for t in tags]
+        assert "sunset" in names
+        assert "ocean" in names
+
+    def test_remove_tag(self, initialized_db):
+        """Removing a tag disassociates it from the photo."""
+        pid = initialized_db.insert_photo(
+            filename="tag_rm.jpg", filepath="/media/tag_rm.jpg"
+        )
+        tag_id = initialized_db.add_tag(pid, "temporary")
+        initialized_db.remove_tag(pid, tag_id)
+
+        tags = initialized_db.get_tags(pid)
+        assert len(tags) == 0
+
+    def test_get_all_tags(self, initialized_db):
+        """get_all_tags returns all tags in the system."""
+        p1 = initialized_db.insert_photo(
+            filename="all_tags1.jpg", filepath="/media/all_tags1.jpg"
+        )
+        p2 = initialized_db.insert_photo(
+            filename="all_tags2.jpg", filepath="/media/all_tags2.jpg"
+        )
+        initialized_db.add_tag(p1, "family")
+        initialized_db.add_tag(p2, "vacation")
+        initialized_db.add_tag(p2, "summer")
+
+        all_tags = initialized_db.get_all_tags()
+        names = [t["name"] for t in all_tags]
+        assert "family" in names
+        assert "vacation" in names
+        assert "summer" in names
+
+    def test_get_all_tags_empty(self, initialized_db):
+        """get_all_tags returns empty list when no tags exist."""
+        all_tags = initialized_db.get_all_tags()
+        assert all_tags == []
+
+    def test_case_insensitive_dedup(self, initialized_db):
+        """Tags with different cases reuse the same tag row."""
+        pid = initialized_db.insert_photo(
+            filename="case_tag.jpg", filepath="/media/case_tag.jpg"
+        )
+        id1 = initialized_db.add_tag(pid, "Nature")
+        id2 = initialized_db.add_tag(pid, "nature")
+
+        tags = initialized_db.get_tags(pid)
+        assert len(tags) == 1
+
+    def test_shared_tag_across_photos(self, initialized_db):
+        """Same tag name applied to different photos uses one tag row."""
+        p1 = initialized_db.insert_photo(
+            filename="shared1.jpg", filepath="/media/shared1.jpg"
+        )
+        p2 = initialized_db.insert_photo(
+            filename="shared2.jpg", filepath="/media/shared2.jpg"
+        )
+        initialized_db.add_tag(p1, "party")
+        initialized_db.add_tag(p2, "party")
+
+        # Only one tag row
+        all_tags = initialized_db.get_all_tags()
+        party_tags = [t for t in all_tags if t["name"] == "party"]
+        assert len(party_tags) == 1

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -4,10 +4,7 @@ Covers: schema creation, WAL mode, CRUD for photos/albums/tags/users,
 duplicate detection, stats buffering, migration, and smart albums.
 """
 
-import os
 import sqlite3
-import tempfile
-import threading
 from contextlib import closing
 from pathlib import Path
 from unittest import mock


### PR DESCRIPTION
## Phase 2, Agent 3: Favorites + Albums

### PhotoCard enhancements
- Favorite star toggle (gold star, calls POST /api/photos/{id}/favorite)
- Selection mode with checkbox (selectable prop)
- Long-press context menu: [FAV], [ADD] TO ALBUM, [DELETE]
- Favorite photos get phosphor left-border

### Lightbox viewer (NEW)
- Full-screen overlay with swipe left/right navigation
- Touch swipe + keyboard arrows + swipe-down to close
- Bottom action bar: [FAV], [INFO], [DELETE]
- Info panel: EXIF date, upload date, view count, file size, dimensions, uploaded by
- Tag management: inline input with autocomplete from existing tags, click-to-remove chips

### Albums page (NEW)
- Grid of album cards (cover placeholder + name + photo count)
- CREATE ALBUM button with ShModal name/description input
- Album detail view: filtered photo grid for that album
- Delete album with confirmation modal (photos preserved)
- Smart albums at top: RECENT, ON THIS DAY, MOST SHOWN (with SMART badge)
- Filter chips: ALL / SMART / USER

### Navigation
- ALBUMS tab added to PhoneLayout bottom nav

### Upload page filter bar
- Filter chips above photo grid: ALL / FAVORITES / HIDDEN
- Passes filter param to GET /api/photos?filter=favorites|hidden

### API additions
- GET /api/photos now accepts ?filter=favorites|hidden query param
- GET /api/albums/{id}/photos — list album photos
- GET /api/albums/smart/{key}/photos — list smart album photos
- GET /api/tags — all tags for autocomplete
- db.get_all_tags() — new DB function
- db.get_albums() now includes photo_count via subquery

### Tests
- 23 new tests in test_albums.py covering favorite toggle, album CRUD, smart albums, tag CRUD, get_all_tags
- Fixtures moved to conftest.py for cross-file sharing (69 total tests pass)

### Conventions
- piOS voice throughout (STANDBY, NO DATA, CONFIRM:)
- .sh-filter-chip + .sh-filter-chip--active for all filters
- ShModal for create/delete confirmations
- No h callback parameter in JSX
- No emoji icons — text labels [FAV], [TAG], [DELETE], [ADD]
- CSS Grid layout with --space-* tokens
- contextlib.closing() + WAL mode for all DB access