### PR TITLE
feat: Phase 4 — TV display improvements

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -122,6 +122,7 @@ def _current_settings():
         "auto_resize_max": _safe_int(config.get("AUTO_RESIZE_MAX", "1920"), 1920),
         "auto_update_enabled": config.get("AUTO_UPDATE_ENABLED", "no").lower() == "yes",
         "pin_length": _safe_int(config.get("PIN_LENGTH", "4"), 4),
+        "max_video_duration": _safe_int(config.get("MAX_VIDEO_DURATION", "30"), 30),
         "web_port": _safe_int(config.get("WEB_PORT", "8080"), 8080),
     }
 
@@ -149,6 +150,7 @@ _SETTINGS_ENV_MAP = {
     "auto_resize_max": ("AUTO_RESIZE_MAX", str),
     "auto_update_enabled": ("AUTO_UPDATE_ENABLED", lambda v: "yes" if v else "no"),
     "pin_length": ("PIN_LENGTH", str),
+    "max_video_duration": ("MAX_VIDEO_DURATION", str),
 }
 
 
@@ -270,6 +272,14 @@ def update_settings():
                 raise ValueError
         except (TypeError, ValueError):
             return jsonify({"error": "Invalid transition_duration_ms: must be 500-3000"}), 400
+
+    if "max_video_duration" in data:
+        try:
+            val = int(data["max_video_duration"])
+            if not (5 <= val <= 300):
+                raise ValueError
+        except (TypeError, ValueError):
+            return jsonify({"error": "Invalid max_video_duration: must be 5-300"}), 400
 
     if "pin_length" in data:
         try:

--- a/app/frontend/src/display/AmbientClock.jsx
+++ b/app/frontend/src/display/AmbientClock.jsx
@@ -1,0 +1,37 @@
+/** @fileoverview Ambient clock — superhot-ui styled screensaver for idle TV display. */
+import { useState, useEffect } from "preact/hooks";
+
+function pad(n) { return String(n).padStart(2, "0"); }
+
+export function AmbientClock() {
+  const [now, setNow] = useState(new Date());
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const hours = pad(now.getHours());
+  const minutes = pad(now.getMinutes());
+  const seconds = pad(now.getSeconds());
+
+  const dateStr = now.toLocaleDateString("en-US", {
+    weekday: "short",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).toUpperCase();
+
+  return (
+    <div class="fc-ambient-clock">
+      <div class="fc-clock-time">
+        <span class="fc-clock-digits">{hours}</span>
+        <span class="fc-clock-separator">:</span>
+        <span class="fc-clock-digits">{minutes}</span>
+        <span class="fc-clock-separator fc-clock-separator--seconds">:</span>
+        <span class="fc-clock-digits fc-clock-digits--seconds">{seconds}</span>
+      </div>
+      <div class="fc-clock-date">{dateStr}</div>
+    </div>
+  );
+}

--- a/app/frontend/src/display/DisplayRouter.jsx
+++ b/app/frontend/src/display/DisplayRouter.jsx
@@ -15,6 +15,7 @@ import { Boot } from "./Boot.jsx";
 import { Welcome } from "./Welcome.jsx";
 import { Setup } from "./Setup.jsx";
 import { Slideshow } from "./Slideshow.jsx";
+import { AmbientClock } from "./AmbientClock.jsx";
 
 /** Current display state -- exported for other components to read. */
 export const displayState = signal("boot");
@@ -72,7 +73,12 @@ function renderState(stateName) {
     case "setup":
       return <Setup />;
     case "welcome":
-      return <Welcome />;
+      return (
+        <>
+          <Welcome />
+          <AmbientClock />
+        </>
+      );
     case "slideshow":
       return <Slideshow />;
     default:

--- a/app/frontend/src/display/Slideshow.jsx
+++ b/app/frontend/src/display/Slideshow.jsx
@@ -21,6 +21,8 @@ const photoList = signal([]);
 const settingsData = signal(null);
 const onThisDayText = signal("");
 const connectionLost = signal(false);
+const currentPhotoData = signal(null);
+const currentPhotoIndex = signal(0);
 
 // --- Constants ---
 const TRANSITION_TYPES = ["fc-fade", "fc-slide", "fc-kenburns", "fc-dissolve"];
@@ -154,8 +156,8 @@ function setLayerContent(layer, photo, onAdvance, cfg) {
     vid.style.cssText =
       "position:absolute;inset:0;width:100%;height:100%;object-fit:contain;";
 
-    // Cap video duration at SLIDESHOW_DURATION * 3 (default 30s)
-    const maxDuration = ((cfg ? cfg.photo_duration : 10) || 10) * 3;
+    // Cap video duration at configured max (default 30s)
+    const maxDuration = (cfg ? cfg.max_video_duration : 30) || 30;
     vid.addEventListener("loadedmetadata", () => {
       if (vid.duration > maxDuration) {
         // Auto-advance after max duration
@@ -202,11 +204,26 @@ function setLayerContent(layer, photo, onAdvance, cfg) {
     layer.appendChild(img);
   }
 
+  // Update info overlay signals
+  currentPhotoData.value = photo;
+  currentPhotoIndex.value = (currentPhotoIndex.value + 1) | 0;
+
   // Show "On This Day" overlay if applicable
   if (photo.on_this_day && photo.years_ago) {
     const yearsAgo = photo.years_ago;
     onThisDayText.value = yearsAgo === 1 ? "1 YEAR AGO" : `${yearsAgo} YEARS AGO`;
   }
+}
+
+/** Format photo metadata for the info overlay. */
+function formatPhotoInfo(photo) {
+  if (!photo) return "";
+  const parts = [];
+  const name = photo.filename || photo.name || "";
+  if (name) parts.push(name);
+  if (photo.exif_date) parts.push(photo.exif_date);
+  if (photo.gps_lat && photo.gps_lon) parts.push(`${photo.gps_lat.toFixed(2)}, ${photo.gps_lon.toFixed(2)}`);
+  return parts.join(" \u2022 ");
 }
 
 /** Fetch a playlist from the server. Returns { photos, playlist_id }. */
@@ -315,9 +332,11 @@ export function Slideshow() {
       const newStandby = s.activeLayer === "A" ? layerBRef.current : layerARef.current;
       newActive.style.zIndex = "2";
       newActive.className = "slideshow-layer";
+      newActive.setAttribute("aria-hidden", "false");
       newStandby.style.zIndex = "1";
       newStandby.style.opacity = "0";
       newStandby.className = "slideshow-layer";
+      newStandby.setAttribute("aria-hidden", "true");
 
       // Preload next 2
       preloadAhead(s.ordered, s.index, 2);
@@ -459,7 +478,7 @@ export function Slideshow() {
   const isEmpty = photoList.value.length === 0;
 
   return (
-    <div class="slideshow-container">
+    <div class="slideshow-container" role="region" aria-label="Photo slideshow" aria-live="polite">
       {isEmpty && (
         <div class="boot-screen">
           <div class="boot-status">STANDBY</div>
@@ -469,13 +488,20 @@ export function Slideshow() {
       <div
         ref={layerARef}
         class="slideshow-layer"
+        aria-hidden="true"
         style="position:absolute;inset:0;z-index:1;opacity:0;"
       />
       <div
         ref={layerBRef}
         class="slideshow-layer"
+        aria-hidden="true"
         style="position:absolute;inset:0;z-index:1;opacity:0;"
       />
+      {currentPhotoData.value && (
+        <div class="fc-info-overlay" key={`info-${currentPhotoIndex.value}`}>
+          <span class="fc-info-text">{formatPhotoInfo(currentPhotoData.value)}</span>
+        </div>
+      )}
       {onThisDayText.value && (
         <div class="fc-otd-overlay" ref={otdOverlayRef}>
           <span class="fc-otd-label">{onThisDayText.value}</span>

--- a/app/frontend/src/display/Welcome.jsx
+++ b/app/frontend/src/display/Welcome.jsx
@@ -1,5 +1,10 @@
 /** @fileoverview Welcome screen — shown when WiFi is connected but no photos exist. */
+import { useState, useEffect } from "preact/hooks";
 import { QRCode } from "../components/QRCode.jsx";
+
+function computeQRSize() {
+  return Math.max(120, Math.min(Math.round(window.innerWidth * 0.25), 320));
+}
 
 /**
  * Welcome — instructs the user to scan QR code to upload photos.
@@ -7,6 +12,13 @@ import { QRCode } from "../components/QRCode.jsx";
  */
 export function Welcome() {
   const url = `http://${window.location.hostname}:8080`;
+  const [qrSize, setQrSize] = useState(computeQRSize);
+
+  useEffect(() => {
+    const onResize = () => setQrSize(computeQRSize());
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
 
   return (
     <div class="boot-screen" style={{ alignItems: "center", textAlign: "center" }}>
@@ -18,7 +30,7 @@ export function Welcome() {
         <p class="sh-label" style={{ marginBottom: "var(--space-4)" }}>
           SCAN TO UPLOAD PHOTOS
         </p>
-        <QRCode url={url} size={256} />
+        <QRCode url={url} size={qrSize} />
         <p class="sh-ansi-dim" style={{ marginTop: "var(--space-4)", fontSize: "var(--type-body)" }}>
           {url}
         </p>

--- a/app/frontend/src/pages/Settings.jsx
+++ b/app/frontend/src/pages/Settings.jsx
@@ -283,6 +283,19 @@ export function Settings() {
                 ))}
               </select>
             </SettingRow>
+
+            <SettingRow label="MAX VIDEO DURATION (S)">
+              <input
+                class="sh-range"
+                type="range"
+                min="5"
+                max="300"
+                step="5"
+                value={settings.max_video_duration || 30}
+                onInput={(evt) => update("max_video_duration", parseInt(evt.target.value, 10))}
+              />
+              <span class="sh-value fc-range-value">{settings.max_video_duration || 30}s</span>
+            </SettingRow>
           </div>
         </ShCollapsible>
       </section>

--- a/app/frontend/src/styles/display.css
+++ b/app/frontend/src/styles/display.css
@@ -19,8 +19,8 @@
 
 .qr-overlay img {
   display: block;
-  width: 120px;
-  height: 120px;
+  width: clamp(80px, 15vw, 160px);
+  height: clamp(80px, 15vw, 160px);
   image-rendering: pixelated;
 }
 
@@ -68,4 +68,55 @@
   padding: 8px 16px;
   border: 1px solid var(--sh-threat);
   z-index: 30;
+}
+
+/* ── Ambient Clock ── */
+
+.fc-ambient-clock {
+  position: fixed;
+  bottom: 100px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.fc-clock-time {
+  font-family: var(--font-mono, monospace);
+  font-size: clamp(2rem, 8vw, 6rem);
+  font-weight: 700;
+  color: var(--sh-phosphor);
+  letter-spacing: 0.05em;
+  text-shadow: 0 0 20px var(--sh-phosphor-glow), 0 0 40px var(--sh-phosphor-glow);
+  line-height: 1;
+}
+
+.fc-clock-separator {
+  opacity: 0.6;
+  animation: fcClockBlink 1s step-end infinite;
+}
+
+@keyframes fcClockBlink {
+  50% { opacity: 0.1; }
+}
+
+.fc-clock-digits--seconds {
+  font-size: 0.5em;
+  opacity: 0.5;
+  vertical-align: baseline;
+}
+
+.fc-clock-separator--seconds {
+  font-size: 0.5em;
+  vertical-align: baseline;
+}
+
+.fc-clock-date {
+  font-family: var(--font-mono, monospace);
+  font-size: clamp(0.75rem, 2vw, 1.25rem);
+  color: var(--sh-phosphor);
+  opacity: 0.5;
+  letter-spacing: 0.2em;
+  margin-top: 12px;
 }

--- a/app/frontend/src/styles/slideshow.css
+++ b/app/frontend/src/styles/slideshow.css
@@ -131,6 +131,42 @@
   animation: fcDissolveOut var(--fc-transition-ms) ease-in-out forwards;
 }
 
+/* --- Photo info overlay --- */
+
+.fc-info-overlay {
+  position: fixed;
+  top: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  pointer-events: none;
+  animation: fcInfoFade 3s ease-in-out forwards;
+}
+
+@keyframes fcInfoFade {
+  0%   { opacity: 0; }
+  10%  { opacity: 1; }
+  75%  { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+.fc-info-text {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(0, 0, 0, 0.7);
+  border: 1px solid var(--sh-phosphor);
+  color: var(--sh-phosphor);
+  font-family: var(--font-mono, monospace);
+  font-size: clamp(0.65rem, 1.2vw, 1rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-shadow: 0 0 8px var(--sh-phosphor-glow);
+  white-space: nowrap;
+  max-width: 90vw;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* --- "On This Day" overlay --- */
 
 .fc-otd-overlay {


### PR DESCRIPTION
## Phase 4: TV Display

5 issues resolved in this phase:

| Issue | Title | Changes |
|-------|-------|---------|
| #52 | Slideshow accessibility attributes | `role="region"`, `aria-label`, `aria-live="polite"`, `aria-hidden` toggled on layer swap |
| #66 | QR code responsive sizing | 25% viewport width, clamped 120-320px, resize listener |
| #60 | Photo info overlay on TV | Translucent bar with filename/date/GPS, CSS-only 3s auto-fade via key remount |
| #62 | Ambient clock mode | 24h phosphor clock on welcome screen, blinking separator, uppercase date |
| #48 | Video slideshow transitions + duration cap | Configurable `max_video_duration` (5-300s, default 30), settings UI slider |

### Files changed (8)
- `app/api.py` — max_video_duration setting + validation
- `app/frontend/src/display/AmbientClock.jsx` — NEW: standalone clock component
- `app/frontend/src/display/DisplayRouter.jsx` — AmbientClock on welcome screen
- `app/frontend/src/display/Slideshow.jsx` — a11y attrs, info overlay, video duration
- `app/frontend/src/display/Welcome.jsx` — responsive QR sizing
- `app/frontend/src/pages/Settings.jsx` — max video duration slider
- `app/frontend/src/styles/display.css` — QR responsive + ambient clock CSS
- `app/frontend/src/styles/slideshow.css` — photo info overlay CSS

Closes #52, #66, #60, #62, #48