### PR TITLE
fix: OTA update pipeline — init git repo, create update-check.sh, pass SHA

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -44,3 +44,6 @@ HDMI_ON_TIME=08:00
 AUTO_REFRESH=yes
 REFRESH_INTERVAL=30
 AUTO_UPDATE_ENABLED=no
+# GitHub repo for OTA updates (override for forks)
+GITHUB_OWNER=parthalon025
+GITHUB_REPO=framecast

--- a/app/frontend/src/pages/Update.jsx
+++ b/app/frontend/src/pages/Update.jsx
@@ -157,7 +157,7 @@ export function Update() {
       const res = await authedFetch("/api/update/apply", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ tag }),
+        body: JSON.stringify({ tag, expected_sha: updateInfo.target_commitish }),
       });
 
       clearInterval(progressTimer.current);

--- a/pi-gen/stage2-framecast/00-packages/00-packages
+++ b/pi-gen/stage2-framecast/00-packages/00-packages
@@ -13,5 +13,6 @@ python3-pil
 python3-pip
 nodejs
 npm
+git
 ufw
 v4l-utils

--- a/pi-gen/stage2-framecast/02-app/01-run-chroot.sh
+++ b/pi-gen/stage2-framecast/02-app/01-run-chroot.sh
@@ -32,6 +32,8 @@ chown -R 1000:1000 /opt/framecast
 chmod +x /opt/framecast/kiosk/kiosk.sh
 chmod +x /opt/framecast/kiosk/browser.js
 chmod +x /opt/framecast/scripts/hdmi-control.sh
+chmod +x /opt/framecast/scripts/update-check.sh
+chmod +x /opt/framecast/scripts/health-check.sh
 
 # Scoped sudoers for service restart and reboot
 SUDOERS_TMP=$(mktemp)

--- a/pi-gen/stage2-framecast/02-app/01-run.sh
+++ b/pi-gen/stage2-framecast/02-app/01-run.sh
@@ -10,6 +10,26 @@ cp -r "${FRAMECAST_SRC}/scripts" "${ROOTFS_DIR}/opt/framecast/"
 cp "${FRAMECAST_SRC}/requirements.txt" "${ROOTFS_DIR}/opt/framecast/"
 cp "${FRAMECAST_SRC}/VERSION" "${ROOTFS_DIR}/opt/framecast/"
 cp "${FRAMECAST_SRC}/Makefile" "${ROOTFS_DIR}/opt/framecast/"
+cp "${FRAMECAST_SRC}/.gitignore" "${ROOTFS_DIR}/opt/framecast/"
+
+# Initialize git repo for OTA updates.
+# Creates a minimal repo with one commit + version tag + GitHub remote.
+# updater.py uses git fetch --tags + git checkout <tag> for OTA.
+VERSION=$(cat "${FRAMECAST_SRC}/VERSION")
+GITHUB_OWNER=$(grep "^GITHUB_OWNER=" "${FRAMECAST_SRC}/app/.env.example" 2>/dev/null | cut -d= -f2- || echo "parthalon025")
+GITHUB_REPO=$(grep "^GITHUB_REPO=" "${FRAMECAST_SRC}/app/.env.example" 2>/dev/null | cut -d= -f2- || echo "framecast")
+GITHUB_OWNER="${GITHUB_OWNER:-parthalon025}"
+GITHUB_REPO="${GITHUB_REPO:-framecast}"
+
+cd "${ROOTFS_DIR}/opt/framecast"
+git init
+git config user.email "framecast@local"
+git config user.name "FrameCast"
+git add -A
+git commit -m "FrameCast v${VERSION}"
+git tag "v${VERSION}"
+git remote add origin "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
+cd -
 
 # Install systemd services
 for svc in framecast.service framecast-kiosk.service wifi-manager.service framecast-update.service framecast-update.timer framecast-health.service framecast-health.timer framecast-schedule.service framecast-schedule.timer; do

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -346,6 +346,61 @@ fi
 echo ""
 
 # -----------------------------------------------------------------------
+# 12. OTA Update Infrastructure
+# -----------------------------------------------------------------------
+echo "--- OTA Update ---"
+
+if command -v git &>/dev/null; then
+    pass "git is installed"
+else
+    fail "git is not installed (required for OTA updates)"
+fi
+
+if [ -d "$INSTALL_DIR/.git" ]; then
+    pass "Git repo initialized at $INSTALL_DIR"
+else
+    fail "No git repo at $INSTALL_DIR — OTA updates will fail"
+fi
+
+if [ -d "$INSTALL_DIR/.git" ]; then
+    REMOTE_URL=$(git -C "$INSTALL_DIR" remote get-url origin 2>/dev/null || echo "")
+    if [ -n "$REMOTE_URL" ]; then
+        pass "Git remote origin: $REMOTE_URL"
+    else
+        fail "Git remote origin not configured"
+    fi
+
+    CURRENT_TAG=$(git -C "$INSTALL_DIR" describe --tags --exact-match 2>/dev/null || echo "")
+    if [ -n "$CURRENT_TAG" ]; then
+        pass "Current git tag: $CURRENT_TAG"
+    else
+        warn "No git tag on current commit (expected vX.Y.Z)"
+    fi
+fi
+
+if [ -x "$INSTALL_DIR/scripts/update-check.sh" ]; then
+    pass "update-check.sh is executable"
+else
+    fail "update-check.sh missing or not executable"
+fi
+
+if [ -x "$INSTALL_DIR/scripts/health-check.sh" ]; then
+    pass "health-check.sh is executable"
+else
+    fail "health-check.sh missing or not executable"
+fi
+
+for TIMER in framecast-update framecast-health; do
+    if systemctl is-enabled "${TIMER}.timer" &>/dev/null; then
+        pass "${TIMER}.timer is enabled"
+    else
+        warn "${TIMER}.timer is not enabled"
+    fi
+done
+
+echo ""
+
+# -----------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------
 TOTAL=$((PASS + FAIL + WARN))

--- a/scripts/update-check.sh
+++ b/scripts/update-check.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# update-check.sh — Daily OTA update check (called by framecast-update.timer)
+#
+# Checks if auto-update is enabled, queries GitHub for a newer release,
+# and optionally applies the update + reboots.
+#
+# Exit codes:
+#   0 - Check completed (update applied, or no update, or auto-update disabled)
+#   1 - Error during check or apply
+set -euo pipefail
+
+INSTALL_DIR="/opt/framecast"
+ENV_FILE="$INSTALL_DIR/app/.env"
+LOG_TAG="framecast-update"
+
+log() { echo "[$LOG_TAG] $*"; }
+
+# Read .env value with default
+env_get() {
+    local key="$1" default="${2:-}"
+    if [ -f "$ENV_FILE" ]; then
+        local val
+        val=$(grep "^${key}=" "$ENV_FILE" 2>/dev/null | cut -d= -f2- || true)
+        echo "${val:-$default}"
+    else
+        echo "$default"
+    fi
+}
+
+# Check if auto-update is enabled
+AUTO_UPDATE=$(env_get "AUTO_UPDATE_ENABLED" "no")
+if [ "${AUTO_UPDATE,,}" != "yes" ]; then
+    log "Auto-update disabled (AUTO_UPDATE_ENABLED=$AUTO_UPDATE)"
+    exit 0
+fi
+
+# Read GitHub repo config (supports forks)
+GITHUB_OWNER=$(env_get "GITHUB_OWNER" "parthalon025")
+GITHUB_REPO=$(env_get "GITHUB_REPO" "framecast")
+API_URL="https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest"
+
+# Read current version
+if [ ! -f "$INSTALL_DIR/VERSION" ]; then
+    log "ERROR: VERSION file not found at $INSTALL_DIR/VERSION"
+    exit 1
+fi
+CURRENT=$(cat "$INSTALL_DIR/VERSION")
+log "Current version: $CURRENT"
+
+# Query GitHub Releases API
+log "Checking $API_URL"
+RESPONSE=$(curl -sf --max-time 30 \
+    -H "Accept: application/vnd.github.v3+json" \
+    -H "User-Agent: FrameCast-Updater" \
+    "$API_URL" 2>&1) || {
+    log "ERROR: GitHub API request failed: $RESPONSE"
+    exit 1
+}
+
+TAG=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tag_name',''))" 2>/dev/null)
+COMMITISH=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('target_commitish',''))" 2>/dev/null)
+
+if [ -z "$TAG" ]; then
+    log "ERROR: No tag_name in GitHub response"
+    exit 1
+fi
+
+# Validate tag format (vX.Y.Z)
+if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    log "ERROR: Invalid tag format: $TAG"
+    exit 1
+fi
+
+LATEST="${TAG#v}"
+log "Latest version: $LATEST"
+
+# Compare versions using Python (reliable semver comparison)
+IS_NEWER=$(python3 -c "
+current = tuple(int(x) for x in '$CURRENT'.split('.'))
+latest = tuple(int(x) for x in '$LATEST'.split('.'))
+print('yes' if latest > current else 'no')
+" 2>/dev/null)
+
+if [ "$IS_NEWER" != "yes" ]; then
+    log "System is up to date (v$CURRENT)"
+    exit 0
+fi
+
+log "Update available: v$CURRENT -> $TAG"
+
+# Apply update via the Python updater module (handles rollback tag, SHA verification, git ops)
+cd "$INSTALL_DIR"
+python3 -c "
+import sys
+sys.path.insert(0, 'app')
+from modules import updater
+success, message = updater.apply_update('$TAG', expected_sha='$COMMITISH')
+print(message)
+sys.exit(0 if success else 1)
+" || {
+    log "ERROR: Update apply failed"
+    exit 1
+}
+
+log "Update applied successfully. Rebooting in 5 seconds..."
+sleep 5
+reboot

--- a/systemd/framecast-health.service
+++ b/systemd/framecast-health.service
@@ -6,6 +6,8 @@ Wants=framecast.service framecast-kiosk.service
 [Service]
 Type=oneshot
 ExecStart=/opt/framecast/scripts/health-check.sh
+ProtectSystem=strict
+ReadWritePaths=/opt/framecast /var/lib/framecast
 NoNewPrivileges=true
 ProtectHome=read-only
 ProtectKernelTunables=true

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,253 @@
+"""Tests for modules/updater.py — OTA update check, apply, and rollback."""
+
+import json
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+# Patch config before import so module-level reads use test values
+with patch("modules.config.get", return_value="test"):
+    from modules import updater
+
+
+# ---------------------------------------------------------------------------
+# validate_tag
+# ---------------------------------------------------------------------------
+
+class TestValidateTag:
+    def test_valid_tags(self):
+        assert updater.validate_tag("v1.0.0") is True
+        assert updater.validate_tag("v0.0.1") is True
+        assert updater.validate_tag("v12.34.56") is True
+
+    def test_invalid_tags(self):
+        assert updater.validate_tag("1.0.0") is False
+        assert updater.validate_tag("v1.0") is False
+        assert updater.validate_tag("v1.0.0-beta") is False
+        assert updater.validate_tag("") is False
+        assert updater.validate_tag("latest") is False
+        assert updater.validate_tag("v1.0.0; rm -rf /") is False
+
+
+# ---------------------------------------------------------------------------
+# get_current_version
+# ---------------------------------------------------------------------------
+
+class TestGetCurrentVersion:
+    def test_reads_version_file(self, tmp_path):
+        vfile = tmp_path / "VERSION"
+        vfile.write_text("2.1.0\n")
+        with patch.object(updater, "VERSION_FILE", vfile):
+            assert updater.get_current_version() == "2.1.0"
+
+    def test_missing_version_file(self, tmp_path):
+        with patch.object(updater, "VERSION_FILE", tmp_path / "MISSING"):
+            assert updater.get_current_version() == "0.0.0"
+
+
+# ---------------------------------------------------------------------------
+# _version_newer
+# ---------------------------------------------------------------------------
+
+class TestVersionNewer:
+    def test_newer(self):
+        assert updater._version_newer("2.0.0", "1.0.0") is True
+        assert updater._version_newer("1.1.0", "1.0.0") is True
+        assert updater._version_newer("1.0.1", "1.0.0") is True
+
+    def test_same(self):
+        assert updater._version_newer("1.0.0", "1.0.0") is False
+
+    def test_older(self):
+        assert updater._version_newer("1.0.0", "2.0.0") is False
+
+    def test_invalid_fallback(self):
+        # Falls back to string comparison
+        assert updater._version_newer("b", "a") is True
+
+
+# ---------------------------------------------------------------------------
+# check_for_update
+# ---------------------------------------------------------------------------
+
+class TestCheckForUpdate:
+    def _mock_api_response(self, tag="v2.0.0", commitish="abc123" * 7):
+        data = json.dumps({
+            "tag_name": tag,
+            "html_url": f"https://github.com/test/test/releases/tag/{tag}",
+            "target_commitish": commitish,
+        }).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = data
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        return mock_resp
+
+    @patch.object(updater, "get_current_version", return_value="1.0.0")
+    @patch("urllib.request.urlopen")
+    def test_update_available(self, mock_urlopen, mock_ver):
+        mock_urlopen.return_value = self._mock_api_response("v2.0.0")
+        result = updater.check_for_update()
+        assert result["available"] is True
+        assert result["latest"] == "2.0.0"
+        assert result["tag_name"] == "v2.0.0"
+        assert result["current"] == "1.0.0"
+
+    @patch.object(updater, "get_current_version", return_value="2.0.0")
+    @patch("urllib.request.urlopen")
+    def test_no_update(self, mock_urlopen, mock_ver):
+        mock_urlopen.return_value = self._mock_api_response("v2.0.0")
+        result = updater.check_for_update()
+        assert result["available"] is False
+
+    @patch.object(updater, "get_current_version", return_value="1.0.0")
+    @patch("urllib.request.urlopen")
+    def test_api_error(self, mock_urlopen, mock_ver):
+        import urllib.error
+        mock_urlopen.side_effect = urllib.error.URLError("network down")
+        result = updater.check_for_update()
+        assert result["available"] is False
+        assert result["current"] == "1.0.0"
+
+    @patch.object(updater, "get_current_version", return_value="1.0.0")
+    @patch("urllib.request.urlopen")
+    def test_missing_tag_name(self, mock_urlopen, mock_ver):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"html_url": ""}).encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+        result = updater.check_for_update()
+        assert result["available"] is False
+
+
+# ---------------------------------------------------------------------------
+# apply_update
+# ---------------------------------------------------------------------------
+
+class TestApplyUpdate:
+    @patch.object(updater, "_git")
+    @patch.object(updater, "_atomic_write")
+    @patch.object(updater, "get_current_version", return_value="1.0.0")
+    @patch.object(updater, "_hmac_sign", return_value="sig123")
+    def test_apply_success_no_sha(self, mock_sign, mock_ver, mock_write, mock_git):
+        mock_git.return_value = (True, "ok")
+        success, msg = updater.apply_update("v2.0.0")
+        assert success is True
+        assert "v2.0.0" in msg
+        # Should have called git fetch and checkout
+        calls = [c[0] for c in mock_git.call_args_list]
+        assert ("fetch", "--tags") in calls
+        assert ("checkout", "v2.0.0") in calls
+
+    @patch.object(updater, "_git")
+    @patch.object(updater, "_atomic_write")
+    @patch.object(updater, "get_current_version", return_value="1.0.0")
+    @patch.object(updater, "_hmac_sign", return_value="sig123")
+    def test_apply_sha_verification_pass(self, mock_sign, mock_ver, mock_write, mock_git):
+        sha = "a" * 40
+        def git_side_effect(*args):
+            if args[0] == "rev-parse":
+                return (True, sha)
+            return (True, "ok")
+        mock_git.side_effect = git_side_effect
+        success, msg = updater.apply_update("v2.0.0", expected_sha=sha)
+        assert success is True
+
+    @patch.object(updater, "_git")
+    @patch.object(updater, "_atomic_write")
+    @patch.object(updater, "get_current_version", return_value="1.0.0")
+    @patch.object(updater, "_hmac_sign", return_value="sig123")
+    def test_apply_sha_mismatch_aborts(self, mock_sign, mock_ver, mock_write, mock_git):
+        expected = "a" * 40
+        actual = "b" * 40
+        def git_side_effect(*args):
+            if args[0] == "rev-parse":
+                return (True, actual)
+            return (True, "ok")
+        mock_git.side_effect = git_side_effect
+        success, msg = updater.apply_update("v2.0.0", expected_sha=expected)
+        assert success is False
+        assert "mismatch" in msg.lower()
+
+    def test_apply_rejects_bad_tag(self):
+        success, msg = updater.apply_update("not-a-tag")
+        assert success is False
+        assert "Invalid" in msg
+
+    @patch.object(updater, "_git")
+    @patch.object(updater, "_atomic_write")
+    @patch.object(updater, "get_current_version", return_value="1.0.0")
+    @patch.object(updater, "_hmac_sign", return_value="sig123")
+    def test_apply_fetch_failure(self, mock_sign, mock_ver, mock_write, mock_git):
+        mock_git.return_value = (False, "network error")
+        success, msg = updater.apply_update("v2.0.0")
+        assert success is False
+        assert "fetch" in msg.lower()
+
+    @patch.object(updater, "_git")
+    @patch.object(updater, "_atomic_write")
+    @patch.object(updater, "get_current_version", return_value="1.0.0")
+    @patch.object(updater, "_hmac_sign", return_value="sig123")
+    def test_apply_checkout_failure(self, mock_sign, mock_ver, mock_write, mock_git):
+        def git_side_effect(*args):
+            if args[0] == "checkout":
+                return (False, "checkout error")
+            return (True, "ok")
+        mock_git.side_effect = git_side_effect
+        success, msg = updater.apply_update("v2.0.0")
+        assert success is False
+        assert "checkout" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# _verify_tag_sha
+# ---------------------------------------------------------------------------
+
+class TestVerifyTagSha:
+    @patch.object(updater, "_git")
+    def test_sha_match(self, mock_git):
+        sha = "a" * 40
+        mock_git.return_value = (True, sha)
+        ok, msg = updater._verify_tag_sha("v1.0.0", sha)
+        assert ok is True
+
+    @patch.object(updater, "_git")
+    def test_sha_mismatch(self, mock_git):
+        mock_git.return_value = (True, "b" * 40)
+        ok, msg = updater._verify_tag_sha("v1.0.0", "a" * 40)
+        assert ok is False
+        assert "mismatch" in msg.lower()
+
+    def test_empty_sha_skips(self):
+        ok, msg = updater._verify_tag_sha("v1.0.0", "")
+        assert ok is True
+        assert "skipped" in msg.lower()
+
+    @patch.object(updater, "_git")
+    def test_git_failure(self, mock_git):
+        mock_git.return_value = (False, "error")
+        ok, msg = updater._verify_tag_sha("v1.0.0", "a" * 40)
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# _atomic_write
+# ---------------------------------------------------------------------------
+
+class TestAtomicWrite:
+    def test_writes_file(self, tmp_path):
+        target = tmp_path / "test.txt"
+        updater._atomic_write(target, "hello")
+        assert target.read_text() == "hello"
+
+    def test_creates_parent_dirs(self, tmp_path):
+        target = tmp_path / "sub" / "dir" / "file.txt"
+        updater._atomic_write(target, "content")
+        assert target.read_text() == "content"
+
+    def test_cleans_up_on_failure(self, tmp_path):
+        target = tmp_path / "test.txt"
+        with patch("builtins.open", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                updater._atomic_write(target, "content")


### PR DESCRIPTION
## Problem

The OTA system was **completely broken** on deployed Pi images. The pi-gen build copies files with `cp -r` but never initializes a git repo at `/opt/framecast`. Since `updater.py` uses `git fetch --tags` + `git checkout <tag>`, every OTA operation would fail silently.

Additionally:
- `scripts/update-check.sh` (referenced by `framecast-update.service`) didn't exist
- The frontend never passed `expected_sha` to `/api/update/apply`, so SHA verification was always skipped
- `framecast-health.service` lacked `ProtectSystem=strict` + `ReadWritePaths`

## Changes

| File | Change |
|------|--------|
| `00-packages` | Add `git` to pi-gen package list |
| `02-app/01-run.sh` | Init minimal git repo (1 commit + tag + remote) during build |
| `02-app/01-run-chroot.sh` | chmod update-check.sh + health-check.sh |
| `scripts/update-check.sh` | **New** — daily timer script (check GitHub, apply if enabled) |
| `Update.jsx` | Pass `target_commitish` as `expected_sha` to apply endpoint |
| `framecast-health.service` | Add `ProtectSystem=strict` + `ReadWritePaths` |
| `.env.example` | Add `GITHUB_OWNER`/`GITHUB_REPO` for fork support |
| `smoke-test.sh` | Add OTA infrastructure checks (section 12) |
| `tests/test_updater.py` | **New** — 25 unit tests for updater module |

## OTA Flow (after fix)

```
Timer (3am daily) → update-check.sh → check GitHub API → apply_update()
                                          ↓
User (Settings page) → POST /api/update/check → POST /api/update/apply
                                          ↓
                    git fetch --tags → verify SHA → git checkout <tag> → reboot
                                          ↓
                    health-check (90s post-boot) → verify services → rollback if failed
```

## Testing

- 221 tests pass (196 existing + 25 new updater tests)
- No regressions