### PR TITLE
feat: Phase 6 — real-time features

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -561,6 +561,37 @@ def remove_photo_tag(photo_id, tag_id):
 # ---------------------------------------------------------------------------
 
 
+@api.route("/slideshow/now-playing", methods=["POST"])
+def slideshow_now_playing():
+    """Called by the TV display when the slideshow advances.
+
+    Broadcasts the current photo to phone clients via SSE so the phone
+    can show a "now playing" indicator.
+    """
+    data = request.get_json(silent=True) or {}
+    sse.notify("slideshow:now_playing", {
+        "photo_id": data.get("photo_id"),
+        "filename": data.get("filename"),
+    })
+    return jsonify({"status": "ok"})
+
+
+@api.route("/slideshow/show/<int:photo_id>", methods=["POST"])
+@require_pin
+def slideshow_show_photo(photo_id):
+    """Tell the TV slideshow to immediately display a specific photo."""
+    photo = db.get_photo_by_id(photo_id)
+    if not photo:
+        abort(404)
+    sse.notify("slideshow:show", {
+        "photo_id": photo["id"],
+        "filename": photo["filename"],
+        "filepath": photo["filepath"],
+        "is_video": bool(photo["is_video"]),
+    })
+    return jsonify({"status": "ok", "photo_id": photo_id})
+
+
 @api.route("/slideshow/playlist")
 def slideshow_playlist():
     """Return a weighted playlist of photos for the slideshow."""

--- a/app/frontend/src/components/ConnectionBanner.jsx
+++ b/app/frontend/src/components/ConnectionBanner.jsx
@@ -1,0 +1,47 @@
+/** @fileoverview TV connection status banner — shown when heartbeat is missed. */
+import { signal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+
+const HEARTBEAT_TIMEOUT = 60000; // 60s
+export const tvConnected = signal(true);
+let lastHeartbeat = Date.now();
+
+/** Call this from SSE listener when heartbeat received. */
+export function onHeartbeat() {
+  lastHeartbeat = Date.now();
+  tvConnected.value = true;
+}
+
+export function ConnectionBanner() {
+  useEffect(() => {
+    const timer = setInterval(() => {
+      if (Date.now() - lastHeartbeat > HEARTBEAT_TIMEOUT) {
+        tvConnected.value = false;
+      }
+    }, 5000);
+    return () => clearInterval(timer);
+  }, []);
+
+  if (tvConnected.value) return null;
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      style="position: fixed; top: 0; left: 0; right: 0; z-index: 200; background: var(--sh-threat, #ff3333); color: #000; font-family: var(--font-mono, monospace); font-size: 0.8rem; text-align: center; padding: 8px 16px; display: flex; align-items: center; justify-content: center; gap: 12px;"
+    >
+      <span style="letter-spacing: 0.1em;">TV CONNECTION LOST</span>
+      <button
+        type="button"
+        onClick={() => {
+          fetch("/api/reboot", { method: "POST" }).catch((err) => {
+            console.warn("ConnectionBanner: reboot request failed", err);
+          });
+        }}
+        style="background: #000; color: var(--sh-threat, #ff3333); border: 1px solid #000; font-family: var(--font-mono, monospace); font-size: 0.75rem; padding: 4px 12px; cursor: pointer; letter-spacing: 0.1em;"
+      >
+        RESTART
+      </button>
+    </div>
+  );
+}

--- a/app/frontend/src/components/Lightbox.jsx
+++ b/app/frontend/src/components/Lightbox.jsx
@@ -286,15 +286,27 @@ export function Lightbox({ onToggleFavorite, onDelete, onAddTag, onRemoveTag, ta
           class={`fc-action-btn${photo.is_favorite ? " fc-action-btn--active" : ""}`}
           onClick={handleFav}
           type="button"
-          style="background: none; border: 1px solid var(--border-subtle); color: inherit; padding: 8px 14px; cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem;"
+          style="background: none; border: 1px solid var(--border-subtle); color: inherit; padding: 8px 14px; cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem; min-width: 44px; min-height: 44px;"
         >
           [FAV]
         </button>
         <button
           class="fc-action-btn"
+          onClick={() => {
+            fetch(`/api/slideshow/show/${photo.id}`, { method: "POST" })
+              .catch((err) => console.warn("Lightbox: show on TV failed", err));
+          }}
+          type="button"
+          aria-label="Show on TV"
+          style="background: none; border: 1px solid var(--sh-phosphor, #39ff14); color: var(--sh-phosphor, #39ff14); padding: 8px 14px; cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem; min-width: 44px; min-height: 44px;"
+        >
+          [TV]
+        </button>
+        <button
+          class="fc-action-btn"
           onClick={toggleInfo}
           type="button"
-          style="background: none; border: 1px solid var(--border-subtle); color: inherit; padding: 8px 14px; cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem;"
+          style="background: none; border: 1px solid var(--border-subtle); color: inherit; padding: 8px 14px; cursor: pointer; font-family: var(--font-mono, monospace); font-size: 0.8rem; min-width: 44px; min-height: 44px;"
         >
           [INFO]
         </button>

--- a/app/frontend/src/components/NowPlaying.jsx
+++ b/app/frontend/src/components/NowPlaying.jsx
@@ -1,0 +1,34 @@
+/** @fileoverview NowPlaying — shows current TV photo at top of Upload page.
+ *
+ * Displays a small thumbnail + filename for the photo currently on the TV.
+ * Updated via SSE "slideshow:now_playing" events.
+ */
+import { signal } from "@preact/signals";
+
+export const nowPlaying = signal(null);
+
+export function NowPlaying() {
+  const photo = nowPlaying.value;
+  if (!photo || !photo.filename) return null;
+
+  return (
+    <div
+      style="display: flex; align-items: center; gap: 10px; padding: 8px 12px; margin-bottom: 8px; border-bottom: 1px solid var(--border-subtle, rgba(255,255,255,0.08));"
+    >
+      <img
+        src={`/thumbnail/${photo.filename}`}
+        onError={(evt) => { evt.target.src = `/media/${photo.filename}`; evt.target.onerror = null; }}
+        alt={photo.filename}
+        style="width: 40px; height: 40px; object-fit: cover; border-radius: 3px; flex-shrink: 0;"
+      />
+      <div style="min-width: 0; flex: 1;">
+        <div style="font-family: var(--font-mono, monospace); font-size: 0.7rem; letter-spacing: 0.1em; color: var(--sh-phosphor, #39ff14); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+          NOW ON TV
+        </div>
+        <div class="sh-ansi-dim" style="font-size: 0.7rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+          {photo.filename}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/components/PhoneLayout.jsx
+++ b/app/frontend/src/components/PhoneLayout.jsx
@@ -4,6 +4,7 @@ import { route, navigate } from "./Router.jsx";
 import { uploadProgress } from "../pages/Upload.jsx";
 import { SearchModal, openSearch } from "./SearchModal.jsx";
 import { openLightbox } from "./Lightbox.jsx";
+import { ConnectionBanner } from "./ConnectionBanner.jsx";
 
 // --- Nav icons (inline SVG, 20x20) ---
 function UploadIcon() {
@@ -93,6 +94,7 @@ function handleSearchSelect(photo) {
 export function PhoneLayout({ children }) {
   return (
     <div style="min-height: 100dvh;">
+      <ConnectionBanner />
       {/* Header bar with search */}
       <div
         class="fc-header"

--- a/app/frontend/src/components/PhotoCard.jsx
+++ b/app/frontend/src/components/PhotoCard.jsx
@@ -131,6 +131,20 @@ export function PhotoCard({
         {isFav ? "\u2665" : "\u2661"}
       </button>
 
+      {/* Show on TV overlay */}
+      <button
+        class="fc-show-btn"
+        onClick={(evt) => {
+          evt.stopPropagation();
+          fetch(`/api/slideshow/show/${photo.id}`, { method: "POST" })
+            .catch((err) => console.warn("PhotoCard: show on TV failed", err));
+        }}
+        aria-label="Show on TV"
+        type="button"
+      >
+        TV
+      </button>
+
       <img
         src={`/thumbnail/${photo.name || photo.filename}`}
         onError={(evt) => { evt.target.src = `/media/${photo.name || photo.filename}`; evt.target.onerror = null; }}

--- a/app/frontend/src/display/DisplayRouter.jsx
+++ b/app/frontend/src/display/DisplayRouter.jsx
@@ -116,6 +116,24 @@ export function DisplayRouter() {
               console.warn("DisplayRouter: status refetch after delete failed", err);
             });
         },
+        "sync": () => {
+          if (cancelled) return;
+          // Peer lost sync — re-check current state
+          fetch("/api/status")
+            .then((res) => res.json())
+            .then((data) => {
+              if (cancelled) return;
+              const totalMedia = (data.photo_count || 0) + (data.video_count || 0);
+              if (totalMedia === 0) {
+                displayState.value = "welcome";
+              } else if (displayState.value === "welcome") {
+                displayState.value = "slideshow";
+              }
+            })
+            .catch((err) => {
+              console.warn("DisplayRouter: sync refetch failed", err);
+            });
+        },
       },
     });
 

--- a/app/frontend/src/display/Slideshow.jsx
+++ b/app/frontend/src/display/Slideshow.jsx
@@ -208,6 +208,15 @@ function setLayerContent(layer, photo, onAdvance, cfg) {
   currentPhotoData.value = photo;
   currentPhotoIndex.value = (currentPhotoIndex.value + 1) | 0;
 
+  // Notify server for "now playing" on phone
+  if (photo.id) {
+    fetch("/api/slideshow/now-playing", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ photo_id: photo.id, filename: photo.filename || photo.name }),
+    }).catch(() => {});
+  }
+
   // Show "On This Day" overlay if applicable
   if (photo.on_this_day && photo.years_ago) {
     const yearsAgo = photo.years_ago;
@@ -458,6 +467,41 @@ export function Slideshow() {
             settingsData.value = cfg;
           } catch (parseErr) {
             console.warn("Slideshow: failed to parse settings:changed SSE data", parseErr);
+          }
+        },
+        "sync": handlePhotoChange,
+        "slideshow:show": (evt) => {
+          if (cancelled) return;
+          try {
+            const photo = JSON.parse(evt.data);
+            const s = state.current;
+            if (!s.transitioning) {
+              const cfg = settingsData.value;
+              const activeEl = s.activeLayer === "A" ? layerARef.current : layerBRef.current;
+              const standbyEl = s.activeLayer === "A" ? layerBRef.current : layerARef.current;
+              setLayerContent(standbyEl, photo, advance, cfg);
+              standbyEl.style.zIndex = "3";
+              standbyEl.style.opacity = "1";
+              standbyEl.className = "slideshow-layer fc-fade-in";
+              activeEl.className = "slideshow-layer fc-fade-out";
+              standbyEl.style.setProperty("--fc-transition-ms", "500ms");
+              activeEl.style.setProperty("--fc-transition-ms", "500ms");
+              setTimeout(() => {
+                s.activeLayer = s.activeLayer === "A" ? "B" : "A";
+                const newActive = s.activeLayer === "A" ? layerARef.current : layerBRef.current;
+                const newStandby = s.activeLayer === "A" ? layerBRef.current : layerARef.current;
+                newActive.style.zIndex = "2";
+                newActive.className = "slideshow-layer";
+                newActive.setAttribute("aria-hidden", "false");
+                newStandby.style.zIndex = "1";
+                newStandby.style.opacity = "0";
+                newStandby.className = "slideshow-layer";
+                newStandby.setAttribute("aria-hidden", "true");
+                resetTimer();
+              }, 500);
+            }
+          } catch (parseErr) {
+            console.warn("Slideshow: failed to parse slideshow:show", parseErr);
           }
         },
       },

--- a/app/frontend/src/lib/tile-cache.js
+++ b/app/frontend/src/lib/tile-cache.js
@@ -1,0 +1,68 @@
+/** @fileoverview Offline tile cache using the Cache API.
+ *
+ * Cache-first strategy: serve from cache when available, fetch from
+ * network otherwise and store the response. On network failure, fall
+ * back to cache silently — the map stays usable offline with whatever
+ * tiles were previously viewed.
+ *
+ * Designed for Pi deployment: MAX_CACHED_TILES caps storage so we
+ * don't fill the SD card. Oldest entries are pruned first (FIFO by
+ * insertion order in the Cache API).
+ */
+
+const CACHE_NAME = "framecast-tiles-v1";
+const MAX_CACHED_TILES = 500;
+
+/**
+ * Fetch a tile URL with cache-first strategy.
+ *
+ * 1. Check cache — return immediately if hit.
+ * 2. Fetch from network — cache the response on success.
+ * 3. On network error — try cache again (covers race with going offline).
+ *
+ * @param {string} url - Tile URL to fetch.
+ * @returns {Promise<Response>}
+ */
+export async function cachedTileFetch(url) {
+  try {
+    const cache = await caches.open(CACHE_NAME);
+    const cached = await cache.match(url);
+    if (cached) return cached;
+
+    const response = await fetch(url);
+    if (response.ok) {
+      cache.put(url, response.clone());
+    }
+    return response;
+  } catch (err) {
+    // Network failed — try cache one more time (may have been cached
+    // between the first check and the fetch attempt).
+    try {
+      const cache = await caches.open(CACHE_NAME);
+      const cached = await cache.match(url);
+      if (cached) return cached;
+    } catch (_e) {
+      /* Cache API unavailable (e.g. non-HTTPS without localhost) */
+    }
+    throw err;
+  }
+}
+
+/**
+ * Prune oldest tiles when cache exceeds MAX_CACHED_TILES.
+ *
+ * Cache API keys() returns entries in insertion order — we delete
+ * from the front (oldest) to stay under the cap.
+ */
+export async function pruneTileCache() {
+  try {
+    const cache = await caches.open(CACHE_NAME);
+    const keys = await cache.keys();
+    if (keys.length > MAX_CACHED_TILES) {
+      const toDelete = keys.slice(0, keys.length - MAX_CACHED_TILES);
+      await Promise.all(toDelete.map((key) => cache.delete(key)));
+    }
+  } catch (_e) {
+    /* No-op if cache unavailable */
+  }
+}

--- a/app/frontend/src/pages/Map.jsx
+++ b/app/frontend/src/pages/Map.jsx
@@ -1,7 +1,13 @@
-/** @fileoverview Photo Map — Leaflet map of GPS-tagged photo locations. */
+/** @fileoverview Photo Map — Leaflet map of GPS-tagged photo locations.
+ *
+ * Tiles are cached via the Cache API (tile-cache.js) so the map works
+ * offline with whatever zoom levels were previously viewed. Cache is
+ * capped at 500 tiles to protect the Pi's SD card.
+ */
 import { useState, useEffect, useRef } from "preact/hooks";
 import L from "leaflet";
 import { fetchWithTimeout } from "../lib/fetch.js";
+import { cachedTileFetch, pruneTileCache } from "../lib/tile-cache.js";
 
 // Leaflet CSS bundled locally at /static/css/leaflet.css (copied by postbuild)
 const LEAFLET_CSS = "/static/css/leaflet.css";
@@ -63,10 +69,37 @@ export function Map() {
       attributionControl: true,
     });
 
-    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    // Cached tile layer — serves from Cache API when available, fetches
+    // from network otherwise. Previously-viewed tiles work offline.
+    const CachedTileLayer = L.TileLayer.extend({
+      createTile: function (coords, done) {
+        const tile = document.createElement("img");
+        const url = this.getTileUrl(coords);
+
+        cachedTileFetch(url)
+          .then((response) => response.blob())
+          .then((blob) => {
+            tile.src = URL.createObjectURL(blob);
+            done(null, tile);
+          })
+          .catch(() => {
+            // Network + cache both failed — let Leaflet show its
+            // default broken-tile placeholder.
+            tile.src = url;
+            done(null, tile);
+          });
+
+        return tile;
+      },
+    });
+
+    new CachedTileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
       attribution: "&copy; OpenStreetMap",
       maxZoom: 19,
     }).addTo(map);
+
+    // Prune old tiles in the background (non-blocking)
+    pruneTileCache();
 
     const markers = locations.map((loc) =>
       L.marker([loc.lat, loc.lon], { icon: markerIcon })

--- a/app/frontend/src/pages/Upload.jsx
+++ b/app/frontend/src/pages/Upload.jsx
@@ -11,6 +11,8 @@ import { applyThreshold } from "superhot-ui";
 import { ShDropzone } from "../components/ShDropzone.jsx";
 import { PhotoGrid } from "../components/PhotoGrid.jsx";
 import { OfflineBanner } from "../components/OfflineBanner.jsx";
+import { NowPlaying, nowPlaying } from "../components/NowPlaying.jsx";
+import { onHeartbeat } from "../components/ConnectionBanner.jsx";
 import { ContextMenu } from "../components/PhotoCard.jsx";
 import { Lightbox, openLightbox } from "../components/Lightbox.jsx";
 import { createSSE } from "../lib/sse.js";
@@ -278,6 +280,16 @@ export function Upload() {
       listeners: {
         "photo:added": handleRefresh,
         "photo:deleted": handleRefresh,
+        "slideshow:now_playing": (evt) => {
+          try {
+            const data = JSON.parse(evt.data);
+            nowPlaying.value = data;
+          } catch (parseErr) {
+            console.warn("Upload: failed to parse now_playing", parseErr);
+          }
+        },
+        "heartbeat": () => onHeartbeat(),
+        "sync": () => handleRefresh(),
       },
     });
     sseRef.current = sse;
@@ -412,6 +424,9 @@ export function Upload() {
         </div>
       )}
       <OfflineBanner />
+
+      {/* Now playing — current photo on TV */}
+      <NowPlaying />
 
       {/* User select modal (shown on first upload if no cookie) */}
       <UserSelectModal onSelected={handleUserSelected} />

--- a/app/frontend/src/styles/photos.css
+++ b/app/frontend/src/styles/photos.css
@@ -74,6 +74,49 @@
   color: var(--sh-phosphor, #40ff40);
 }
 
+/* Show on TV overlay button */
+.fc-show-btn {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  z-index: 2;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid var(--sh-phosphor, #39ff14);
+  color: var(--sh-phosphor, #39ff14);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.65rem;
+  padding: 4px 6px;
+  min-width: 32px;
+  min-height: 32px;
+  cursor: pointer;
+  border-radius: 2px;
+  letter-spacing: 0.1em;
+  opacity: 0;
+  transition: opacity 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+/* Show on card hover or focus */
+.sh-card:hover .fc-show-btn,
+.fc-show-btn:focus {
+  opacity: 1;
+}
+
+/* Always visible on touch devices */
+@media (hover: none) {
+  .fc-show-btn {
+    opacity: 0.7;
+  }
+}
+
+/* Hide TV button when selection checkbox occupies the same corner */
+.fc-select-check ~ .fc-show-btn {
+  display: none;
+}
+
 /* Lightbox overlay — capture horizontal swipe, allow vertical scroll */
 .fc-lightbox-overlay {
   touch-action: pan-y;

--- a/app/sse.py
+++ b/app/sse.py
@@ -147,6 +147,10 @@ def subscribe(last_event_id=None):
 
                 # Send keepalive comment to prevent connection timeout
                 yield ": keepalive\n\n"
+
+                # Send heartbeat event (clients use this to detect TV connection)
+                hb_eid = _next_event_id()
+                yield f"id: {hb_eid}\nevent: heartbeat\ndata: {{\"ts\": {int(time.time())}}}\n\n"
     except (BrokenPipeError, GeneratorExit):
         # Client disconnected — expected during normal operation (Lesson #36)
         pass
@@ -197,6 +201,16 @@ def notify(event: str, data: dict | None = None):
 
     if stale:
         log.warning("Dropped %d stale SSE client(s)", len(stale))
+        # Notify remaining clients that some peers lost sync — they should refetch
+        sync_eid = _next_event_id()
+        with _recent_lock:
+            _recent_events.append((sync_eid, "sync", {"reason": "client_overflow"}))
+        with _clients_lock:
+            for q in _clients:
+                try:
+                    q.put_nowait((sync_eid, "sync", {"reason": "client_overflow"}))
+                except Full:
+                    pass  # If this one is also full, it'll be cleaned next cycle
 
 
 def client_count():


### PR DESCRIPTION
## Phase 6: Real-Time

5 issues resolved:

| Issue | Title | Changes |
|-------|-------|---------|
| #39 | SSE sync on overflow | Broadcast `sync` meta-event when stale clients dropped from ring buffer |
| #74 | Heartbeat + TV lost banner | 20s `heartbeat` SSE event, 60s timeout `ConnectionBanner` with RESTART button |
| #63 | Now playing indicator | TV POSTs to `/api/slideshow/now-playing`, `NowPlaying` component on Upload page |
| #73 | Show This Photo Now | `POST /api/slideshow/show/:id`, TV SSE crossfade handler, TV button in PhotoCard + Lightbox |
| #51 | Map offline tile caching | Cache API `tile-cache.js`, `CachedTileLayer`, 500-tile FIFO pruning, zero deps |

### Files changed (10 modified + 3 new)
- `app/sse.py` — sync broadcast on overflow, heartbeat event in subscribe
- `app/api.py` — now-playing + show-photo endpoints
- `app/frontend/src/components/ConnectionBanner.jsx` — NEW: TV connection lost banner
- `app/frontend/src/components/NowPlaying.jsx` — NEW: now-playing thumbnail indicator
- `app/frontend/src/lib/tile-cache.js` — NEW: Cache API tile caching
- `app/frontend/src/display/Slideshow.jsx` — sync + slideshow:show SSE handlers
- `app/frontend/src/display/DisplayRouter.jsx` — sync handler
- `app/frontend/src/pages/Upload.jsx` — heartbeat + now_playing SSE wiring
- `app/frontend/src/pages/Map.jsx` — CachedTileLayer integration
- `app/frontend/src/components/PhoneLayout.jsx` — ConnectionBanner
- `app/frontend/src/components/PhotoCard.jsx` — TV button
- `app/frontend/src/components/Lightbox.jsx` — TV button + touch targets
- `app/frontend/src/styles/photos.css` — .fc-show-btn styles

Closes #39, #74, #63, #73, #51