### PR TITLE
docs: revised API consolidation + superhot-ui plan

### DIFF
--- a/docs/plans/2026-03-20-api-ui-superhot-plan.md
+++ b/docs/plans/2026-03-20-api-ui-superhot-plan.md
@@ -1,10 +1,10 @@
-# FrameCast API↔UI + superhot-ui Maximization Implementation Plan
+# FrameCast API Consolidation + superhot-ui Maximization Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Wire all disconnected API endpoints to the phone SPA UI and maximize superhot-ui component usage from 32% to 68%, validated by the atmosphere-reviewer agent.
+**Goal:** Consolidate all API endpoints into the `api.py` blueprint, retire the legacy v1 template interface, activate the phone SPA at `/`, and maximize superhot-ui component usage from 32% to 68%.
 
-**Architecture:** Settings Expansion + component uplift across all pages. No new routes. 10 new superhot-ui Preact components + 6 JS utilities added. Backend adds 1 new endpoint. Atmosphere reviewer validates the entire UI at the end.
+**Architecture:** Three-phase approach: (1) backend API migration — move misplaced routes, make upload/delete JSON-only, serve SPA at `/`, delete dead templates; (2) app infrastructure — centralized toast, heartbeat, incident state; (3) page-by-page superhot-ui uplift + atmosphere validation. No new API routes except quarantine. Frontend build validates each batch.
 
 **Tech Stack:** Preact, JSX, esbuild, superhot-ui (0.4.0), Flask, SQLite
 
@@ -19,6 +19,317 @@
 - All touch targets: ≥44px, 8px spacing between interactive elements
 - All inputs: ≥16px font-size (prevents iOS auto-zoom)
 - All imports from superhot-ui: `from "superhot-ui/preact"` for components, `from "superhot-ui/js/<module>.js"` for utilities
+- Stage specific files only (`git add <files>`) — never `git add -A`
+
+---
+
+## Batch 0: API Consolidation — Backend Migration
+
+### Task 0.1: Move 3 misplaced /api/* routes from web_upload.py to api.py
+
+**Files:**
+- Modify: `app/web_upload.py` (remove lines 918-951)
+- Modify: `app/api.py` (add after OTA update section, before line 1220)
+- Test: `tests/test_api_integration.py`
+
+**Step 1: Write failing test for the moved routes**
+
+In `tests/test_api_integration.py`, add after existing tests:
+```python
+def test_restart_slideshow_in_api_blueprint(client):
+    """POST /api/restart-slideshow should be handled by the API blueprint."""
+    with mock.patch("modules.services.restart_slideshow", return_value=(True, "restarted")):
+        resp = client.post("/api/restart-slideshow")
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "ok"
+
+
+def test_reboot_in_api_blueprint(client):
+    """POST /api/reboot should be handled by the API blueprint."""
+    with mock.patch("subprocess.Popen"):
+        resp = client.post("/api/reboot")
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "ok"
+
+
+def test_shutdown_in_api_blueprint(client):
+    """POST /api/shutdown should be handled by the API blueprint."""
+    with mock.patch("subprocess.Popen"):
+        resp = client.post("/api/shutdown")
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "ok"
+```
+
+**Step 2: Run tests to verify they pass with current code**
+
+Run: `cd app && python3 -m pytest ../tests/test_api_integration.py -k "restart_slideshow_in_api or reboot_in_api or shutdown_in_api" -v`
+Expected: PASS (routes exist in web_upload.py, still accessible)
+
+**Step 3: Cut the 3 routes from web_upload.py**
+
+Remove from `app/web_upload.py` (lines 918-951):
+- `restart_slideshow()` route
+- `api_reboot()` route
+- `api_shutdown()` route
+
+Also remove the `services` import from line 36 (`from modules import config, db, media, services, wifi` → `from modules import config, db, media, wifi`).
+
+**Step 4: Add the 3 routes to api.py**
+
+In `app/api.py`, add a new section before the OTA Update section (before line 1187):
+```python
+# ---------------------------------------------------------------------------
+# System control endpoints (migrated from web_upload.py)
+# ---------------------------------------------------------------------------
+
+
+@api.route("/restart-slideshow", methods=["POST"])
+@require_pin
+def restart_slideshow():
+    """Restart the slideshow service."""
+    from modules import services
+    success, message = services.restart_slideshow()
+    if success:
+        return jsonify({"status": "ok", "message": message})
+    return jsonify({"error": message}), 500
+
+
+@api.route("/reboot", methods=["POST"])
+@require_pin
+def api_reboot():
+    """Reboot the device."""
+    try:
+        log.info("Reboot requested via web UI")
+        subprocess.Popen(["sudo", "reboot"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return jsonify({"status": "ok", "message": "Device is rebooting..."})
+    except Exception:
+        log.error("Failed to reboot", exc_info=True)
+        return jsonify({"error": "Failed to reboot"}), 500
+
+
+@api.route("/shutdown", methods=["POST"])
+@require_pin
+def api_shutdown():
+    """Shut down the device."""
+    try:
+        log.info("Shutdown requested via web UI")
+        subprocess.Popen(["sudo", "shutdown", "-h", "now"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return jsonify({"status": "ok", "message": "Device is shutting down..."})
+    except Exception:
+        log.error("Failed to shut down", exc_info=True)
+        return jsonify({"error": "Failed to shut down"}), 500
+```
+
+**Step 5: Run tests to verify routes still work**
+
+Run: `cd app && python3 -m pytest ../tests/test_api_integration.py -k "restart_slideshow_in_api or reboot_in_api or shutdown_in_api" -v`
+Expected: PASS
+
+**Step 6: Run full test suite**
+
+Run: `cd app && python3 -m pytest ../tests/ -v --timeout=120`
+Expected: All pass
+
+**Step 7: Commit**
+```bash
+git add app/api.py app/web_upload.py tests/test_api_integration.py
+git commit -m "refactor: move restart-slideshow, reboot, shutdown routes to api.py blueprint"
+```
+
+---
+
+### Task 0.2: Make upload/delete/delete-all JSON-only
+
+**Files:**
+- Modify: `app/web_upload.py`
+
+**Step 1: Remove `_is_xhr()` helper**
+
+Delete the `_is_xhr()` function (lines 424-429 in web_upload.py).
+
+**Step 2: Make `POST /upload` JSON-only**
+
+In the `upload()` function:
+- Replace `if not _upload_semaphore.acquire(blocking=False):` block — remove the `if _is_xhr():`/`else:` branching, keep only the JSON response path:
+  ```python
+  if not _upload_semaphore.acquire(blocking=False):
+      return jsonify({"error": "Another upload is in progress"}), 429
+  ```
+
+In `_do_upload()`:
+- Remove `xhr = _is_xhr()` (first line of function).
+- Replace every `if xhr:` / `if not xhr:` branch with just the JSON response. Remove all `flash()` calls and `redirect(url_for("index"))` returns.
+- At the end, remove the `if xhr:` check — always return JSON:
+  ```python
+  return jsonify({
+      "uploaded": uploaded_names,
+      "uploaded_count": uploaded,
+      "skipped": skipped,
+  }), 200 if uploaded > 0 else 400
+  ```
+
+**Step 3: Make `POST /delete` JSON-only**
+
+Remove all `_is_xhr()` checks and `flash()`/`redirect()` branches. Keep only JSON responses.
+
+**Step 4: Make `POST /delete-all` JSON-only**
+
+Remove the `_is_xhr()` check at the end (line 758). Always return JSON:
+```python
+return jsonify({"status": "ok", "deleted": count})
+```
+
+Remove the `flash` and `redirect` fallbacks.
+
+**Step 5: Clean up imports**
+
+Remove unused imports from web_upload.py:
+- Remove `flash` from the Flask import line
+- Remove `redirect` from the Flask import line
+- Remove `url_for` from the Flask import line
+
+The import line should become:
+```python
+from flask import (
+    Flask,
+    abort,
+    jsonify,
+    request,
+    send_from_directory,
+)
+```
+
+**Step 6: Run full test suite**
+
+Run: `cd app && python3 -m pytest ../tests/ -v --timeout=120`
+Expected: All pass
+
+**Step 7: Commit**
+```bash
+git add app/web_upload.py
+git commit -m "refactor: make upload/delete/delete-all JSON-only — remove dual-mode _is_xhr branching"
+```
+
+---
+
+### Task 0.3: Serve SPA at / — retire dead template routes
+
+**Files:**
+- Modify: `app/web_upload.py`
+- Test: `tests/test_api_integration.py`
+
+**Step 1: Write test for SPA at /**
+
+In `tests/test_api_integration.py`, add:
+```python
+def test_root_serves_spa_shell(client):
+    """GET / should serve the SPA shell (spa.html), not the legacy index.html."""
+    resp = client.get("/")
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert 'id="app"' in html
+    assert "superhot.css" in html
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd app && python3 -m pytest ../tests/test_api_integration.py::test_root_serves_spa_shell -v`
+Expected: FAIL — currently serves `index.html` which doesn't have `id="app"` or `superhot.css`
+
+**Step 3: Replace the index route and delete dead routes**
+
+In `app/web_upload.py`:
+
+Replace the existing `GET /` route (the `index()` function at ~line 402) with:
+```python
+@app.route("/")
+def index():
+    return render_template("spa.html", version=_read_version())
+```
+
+Delete these dead routes entirely:
+- `GET /map` — `map_page()` function
+- `GET /settings` — `settings_page()` function
+- `POST /settings` — `settings_save()` function (entire function including all validation)
+
+Also delete the `config.load_env` import reference if `config` is no longer needed for template data (it's still needed for other functions, so keep the import).
+
+**Step 4: Add SPA catch-all for client-side routes**
+
+The SPA uses pushState routing for `/albums`, `/settings`, `/map`, `/stats`, `/users`. Flask needs to serve `spa.html` for these too. Add after the existing `/update` route:
+
+```python
+@app.route("/albums")
+@app.route("/stats")
+@app.route("/users")
+def spa_phone_routes():
+    """Serve SPA shell for all phone client-side routes."""
+    return render_template("spa.html", version=_read_version())
+```
+
+Note: `/map` and `/settings` are removed above (were legacy template routes), so add them here:
+```python
+@app.route("/map")
+@app.route("/settings")
+@app.route("/albums")
+@app.route("/stats")
+@app.route("/users")
+def spa_phone_routes():
+    """Serve SPA shell for all phone client-side routes."""
+    return render_template("spa.html", version=_read_version())
+```
+
+**Step 5: Run test to verify SPA is served at /**
+
+Run: `cd app && python3 -m pytest ../tests/test_api_integration.py::test_root_serves_spa_shell -v`
+Expected: PASS
+
+**Step 6: Run full test suite**
+
+Run: `cd app && python3 -m pytest ../tests/ -v --timeout=120`
+Expected: All pass
+
+**Step 7: Commit**
+```bash
+git add app/web_upload.py tests/test_api_integration.py
+git commit -m "refactor: serve SPA at / — retire legacy index/map/settings templates, add catch-all"
+```
+
+---
+
+### Task 0.4: Delete dead template files
+
+**Files:**
+- Delete: `app/templates/index.html`
+- Delete: `app/templates/map.html`
+- Delete: `app/templates/settings.html`
+
+**Step 1: Verify the templates are no longer referenced**
+
+Run: `grep -rn "index.html\|map.html\|settings.html" app/web_upload.py app/api.py`
+Expected: No matches (all references removed in previous tasks)
+
+**Step 2: Delete the files**
+
+```bash
+rm app/templates/index.html app/templates/map.html app/templates/settings.html
+```
+
+**Step 3: Verify only spa.html remains**
+
+Run: `ls app/templates/`
+Expected: `spa.html` only
+
+**Step 4: Run full test suite**
+
+Run: `cd app && python3 -m pytest ../tests/ -v --timeout=120`
+Expected: All pass
+
+**Step 5: Commit**
+```bash
+git add -u app/templates/
+git commit -m "chore: delete dead legacy templates (index.html, map.html, settings.html)"
+```
 
 ---
 
@@ -52,7 +363,7 @@ Expected: FAIL — 404 Not Found
 
 **Step 3: Implement the endpoint**
 
-In `app/api.py`, add after the favorite toggle route:
+In `app/api.py`, add after the favorite toggle route (~line 511):
 ```python
 @api.route("/photos/<int:photo_id>/quarantine", methods=["POST"])
 def quarantine_photo(photo_id):
@@ -177,14 +488,14 @@ git commit -m "feat: incident state manager for device-level alerts"
 
 **Step 1: Add heartbeat monitoring**
 
-Add imports at top:
+Add imports at top of app.jsx (after existing superhot-ui imports on line 15):
 ```jsx
 import { startHeartbeat } from "superhot-ui/js/heartbeat.js";
 import { triggerRecovery } from "superhot-ui/js/recovery.js";
 import { raiseIncident, clearIncident } from "./lib/incident.js";
 ```
 
-Add to the app init (inside the existing `useEffect` or at module level after capability detection):
+Add after the theme restoration block (after the `detectCapability`/`applyCapability`/`setFacilityState` calls):
 ```jsx
 let consecutiveFailures = 0;
 
@@ -200,7 +511,7 @@ startHeartbeat(30000, async () => {
       consecutiveFailures = 0;
       return true;
     }
-  } catch (_) { /* network error */ }
+  } catch (_err) { /* network error */ }
   consecutiveFailures++;
   if (consecutiveFailures >= 3) {
     raiseIncident("NETWORK UNREACHABLE", "error");
@@ -267,16 +578,7 @@ Inside the PhoneLayout return, before or after the `<ShNav>`, add:
 )}
 ```
 
-**Step 3: Add map nav visibility toggle**
-
-Read localStorage pref to show/hide Map tab:
-```jsx
-const showMap = localStorage.getItem("fc_show_map") !== "false";
-```
-
-Filter the nav items array to conditionally include/exclude the Map tab based on this preference.
-
-**Step 4: Build and commit**
+**Step 3: Build and commit**
 ```bash
 cd app/frontend && npm run build
 git add app/frontend/src/components/PhoneLayout.jsx
@@ -391,23 +693,35 @@ git commit -m "feat: ShEmptyState + ShErrorState on all data pages"
 
 ---
 
-## Batch 6: Settings Page — Full API Coverage
+## Batch 6: Settings Page — System Controls + superhot-ui Uplift
 
-### Task 6.1: Add SYSTEM rows (backup download, reboot, shutdown)
+**Note:** Phase 8 already added timezone, SSH/HTTPS toggles, guest upload, dark/light mode, frame discovery, settings import/export, and transition preview to Settings.jsx. This batch adds ONLY what's missing: reboot/shutdown modals, TV status badge, MAP section, CRT toggle, audio pref, and download backup.
+
+### Task 6.1: Add reboot + shutdown with ShThreatPulse modals
 
 **Files:**
 - Modify: `app/frontend/src/pages/Settings.jsx`
 
 **Step 1: Add imports**
 
+Add to existing import line (line 8):
 ```jsx
-import { ShThreatPulse, ShStatusBadge, ShCrtToggle } from "superhot-ui/preact";
+import { ShCollapsible, ShModal, ShToast, ShSkeleton, ShThreatPulse, ShStatusBadge } from "superhot-ui/preact";
 import { playSfx } from "superhot-ui/js/audio.js";
 import { showToast } from "../lib/toast.js";
 ```
 
-**Step 2: Add DOWNLOAD BACKUP row after RESTORE BACKUP**
+**Step 2: Add state variables**
 
+Add to the existing useState block (around line 65):
+```jsx
+const [rebootOpen, setRebootOpen] = useState(false);
+const [shutdownOpen, setShutdownOpen] = useState(false);
+```
+
+**Step 3: Add DOWNLOAD BACKUP row in SYSTEM section**
+
+In the SYSTEM section (around line 855, after RESTORE BACKUP row), add:
 ```jsx
 <SettingRow label="DOWNLOAD BACKUP">
   <a
@@ -420,8 +734,9 @@ import { showToast } from "../lib/toast.js";
 </SettingRow>
 ```
 
-**Step 3: Add REBOOT DEVICE row**
+**Step 4: Add REBOOT DEVICE row in SYSTEM section**
 
+After DOWNLOAD BACKUP:
 ```jsx
 <SettingRow label="REBOOT DEVICE">
   <button
@@ -434,41 +749,7 @@ import { showToast } from "../lib/toast.js";
 </SettingRow>
 ```
 
-Add state: `const [rebootOpen, setRebootOpen] = useState(false);`
-
-Add modal (near existing restart modal):
-```jsx
-<ShModal
-  open={rebootOpen}
-  title="CONFIRM: REBOOT DEVICE?"
-  body="SLIDESHOW INTERRUPTS. RESTARTS IN ~30s."
-  confirmLabel="REBOOT"
-  cancelLabel="CANCEL"
-  onConfirm={async () => {
-    setRebootOpen(false);
-    showToast("REBOOTING — STANDBY", "info", 0);
-    try {
-      await fetch("/api/reboot", { method: "POST" });
-      // Poll for recovery
-      const poll = setInterval(async () => {
-        try {
-          const res = await fetch("/api/status");
-          if (res.ok) {
-            clearInterval(poll);
-            showToast("SYSTEM ONLINE", "info");
-            window.location.reload();
-          }
-        } catch (_) { /* still rebooting */ }
-      }, 3000);
-    } catch (err) {
-      showToast("REBOOT FAILED: " + err.message, "error");
-    }
-  }}
-  onCancel={() => setRebootOpen(false)}
-/>
-```
-
-**Step 4: Add SHUT DOWN row**
+**Step 5: Add SHUT DOWN row in SYSTEM section**
 
 ```jsx
 <SettingRow label="SHUT DOWN">
@@ -482,9 +763,41 @@ Add modal (near existing restart modal):
 </SettingRow>
 ```
 
-Add state: `const [shutdownOpen, setShutdownOpen] = useState(false);`
+**Step 6: Add reboot confirmation modal**
 
-Add modal with ShThreatPulse:
+Add near the existing restart modal (around line 969):
+```jsx
+<ShModal
+  open={rebootOpen}
+  title="CONFIRM: REBOOT DEVICE?"
+  body="SLIDESHOW INTERRUPTS. RESTARTS IN ~30s."
+  confirmLabel="REBOOT"
+  cancelLabel="CANCEL"
+  onConfirm={async () => {
+    setRebootOpen(false);
+    showToast("REBOOTING — STANDBY", "info", 0);
+    try {
+      await fetch("/api/reboot", { method: "POST" });
+      const poll = setInterval(async () => {
+        try {
+          const res = await fetch("/api/status");
+          if (res.ok) {
+            clearInterval(poll);
+            showToast("SYSTEM ONLINE", "info");
+            window.location.reload();
+          }
+        } catch (_err) { /* still rebooting */ }
+      }, 3000);
+    } catch (err) {
+      showToast("REBOOT FAILED: " + err.message, "error");
+    }
+  }}
+  onCancel={() => setRebootOpen(false)}
+/>
+```
+
+**Step 7: Add shutdown modal wrapped in ShThreatPulse**
+
 ```jsx
 <ShThreatPulse active={shutdownOpen} persistent>
   <ShModal
@@ -498,14 +811,14 @@ Add modal with ShThreatPulse:
       showToast("SHUTTING DOWN", "error", 0);
       try {
         await fetch("/api/shutdown", { method: "POST" });
-      } catch (_) { /* expected — device is shutting down */ }
+      } catch (_err) { /* expected — device is shutting down */ }
     }}
     onCancel={() => setShutdownOpen(false)}
   />
 </ShThreatPulse>
 ```
 
-**Step 5: Build and commit**
+**Step 8: Build and commit**
 ```bash
 cd app/frontend && npm run build
 git add app/frontend/src/pages/Settings.jsx
@@ -514,14 +827,14 @@ git commit -m "feat: Settings SYSTEM — backup download, reboot, shutdown with 
 
 ---
 
-### Task 6.2: Add SCHEDULE TV status + MAP section + DISPLAY prefs
+### Task 6.2: Add TV status badge, MAP section, CRT toggle, audio pref
 
 **Files:**
 - Modify: `app/frontend/src/pages/Settings.jsx`
 
 **Step 1: Add TV STATUS row to SCHEDULE section**
 
-After the DISPLAY POWER toggle row:
+After the DISPLAY POWER toggle row (line 674), add:
 ```jsx
 <SettingRow label="TV STATUS">
   <ShStatusBadge
@@ -535,7 +848,6 @@ Add state and fetch:
 ```jsx
 const [tvStatus, setTvStatus] = useState(null);
 
-// Fetch on SCHEDULE section expand
 const fetchTvStatus = () => {
   fetch("/api/display/status")
     .then((res) => res.json())
@@ -588,11 +900,11 @@ fetchWithTimeout("/api/locations").then((res) => res.json()).then((locs) => setG
 
 ```jsx
 <SettingRow label="CRT EFFECT">
-  <ShCrtToggle
-    intensity={crtIntensity}
-    onIntensityChange={(val) => {
-      setCrtIntensity(val);
-      localStorage.setItem("fc_crt_intensity", val);
+  <Toggle
+    on={crtEnabled}
+    onToggle={(val) => {
+      setCrtEnabled(val);
+      localStorage.setItem("fc_crt_enabled", val ? "true" : "false");
     }}
   />
 </SettingRow>
@@ -606,6 +918,12 @@ fetchWithTimeout("/api/locations").then((res) => res.json()).then((locs) => setG
     }}
   />
 </SettingRow>
+```
+
+Add state:
+```jsx
+const [crtEnabled, setCrtEnabled] = useState(localStorage.getItem("fc_crt_enabled") !== "false");
+const [audioEnabled, setAudioEnabled] = useState(localStorage.getItem("fc_audio_enabled") === "true");
 ```
 
 **Step 4: Build and commit**
@@ -687,7 +1005,6 @@ import { showToast } from "../lib/toast.js";
 
 In the existing `useEffect` that runs on photo change, add:
 ```jsx
-// Fetch albums for add-to-album feature
 fetch("/api/albums").then((res) => res.json()).then(setAlbums).catch(() => {});
 ```
 
@@ -769,12 +1086,11 @@ git commit -m "feat: Lightbox — add-to-album dropdown + duplicate detection ba
 **Files:**
 - Modify: `app/frontend/src/pages/Albums.jsx`
 
-**Step 1: Add remove action to album photo context menu**
+**Step 1: Add remove action to album photo view**
 
-When browsing an album's photos, add a "REMOVE" context menu item to each PhotoCard. The exact implementation depends on how the existing context menu works in PhotoCard — look for the existing pattern (favorite, tags, etc.) and follow it.
+When browsing an album's photos, add a "REMOVE" context menu item to each PhotoCard. Follow the existing context menu pattern (favorite, tags, etc.):
 
 ```jsx
-// When viewing album photos, pass an onRemove handler:
 <PhotoGrid
   photos={albumPhotos}
   onRemove={selectedAlbum.value ? (photo) => {
@@ -799,7 +1115,7 @@ git commit -m "feat: remove-from-album action in album photo view"
 
 ---
 
-## Batch 9: Upload — Search Wiring
+## Batch 9: Upload — Search Wiring + Bulk Bar superhot-ui Uplift
 
 ### Task 9.1: Wire search icon to SearchModal
 
@@ -807,15 +1123,21 @@ git commit -m "feat: remove-from-album action in album photo view"
 - Modify: `app/frontend/src/pages/Upload.jsx`
 - Modify: `app/frontend/src/components/SearchModal.jsx` (verify API wiring)
 
-**Step 1: Add search icon to Upload header**
+**Step 1: Verify SearchModal API wiring**
 
+Read `app/frontend/src/components/SearchModal.jsx` and verify it calls `/api/search?q=...`. If it uses raw `fetch`, change to `fetchWithTimeout`.
+
+**Step 2: Verify search integration**
+
+Check if SearchModal is already wired in Upload.jsx (Phase 3 commit `3100e90` may have done this). If already wired, skip this task. If not:
+
+Add search button in the Upload header and wire SearchModal:
 ```jsx
 import SearchModal from "../components/SearchModal.jsx";
 
-// Add state:
 const [searchOpen, setSearchOpen] = useState(false);
 
-// In the header area, add search button:
+// In header area:
 <button
   class="sh-input sh-clickable"
   style="min-width: 44px; min-height: 44px; padding: 8px; background: none; border: none; color: var(--sh-phosphor); font-size: 1.2rem;"
@@ -825,19 +1147,63 @@ const [searchOpen, setSearchOpen] = useState(false);
   &#x1F50D;
 </button>
 
-// After the header, add modal:
 <SearchModal open={searchOpen} onClose={() => setSearchOpen(false)} />
 ```
-
-**Step 2: Verify SearchModal uses authedFetch**
-
-Read `app/frontend/src/components/SearchModal.jsx` and verify it calls `/api/search?q=...`. If it uses raw `fetch`, change to `fetchWithTimeout` or `authedFetch`.
 
 **Step 3: Build and commit**
 ```bash
 cd app/frontend && npm run build
 git add app/frontend/src/pages/Upload.jsx app/frontend/src/components/SearchModal.jsx
 git commit -m "feat: search icon in Upload header → wired to SearchModal + /api/search"
+```
+
+---
+
+### Task 9.2: superhot-ui uplift for Phase 8 bulk action bar
+
+**Files:**
+- Modify: `app/frontend/src/pages/Upload.jsx`
+
+**Step 1: Add imports**
+
+```jsx
+import { ShThreatPulse, ShStatusBadge } from "superhot-ui/preact";
+import { showToast } from "../lib/toast.js";
+```
+
+**Step 2: Upgrade bulk action bar**
+
+Find the existing `fc-bulk-bar` div (around line 690) and upgrade:
+- Replace the raw count span with `ShStatusBadge`:
+  ```jsx
+  <ShStatusBadge status="warning" label={`${selectedIds.value.size} SELECTED`} />
+  ```
+- Wrap the DELETE button in `ShThreatPulse`:
+  ```jsx
+  <ShThreatPulse active={selectedIds.value.size > 0}>
+    <button
+      class="fc-bulk-bar__btn fc-bulk-bar__btn--danger"
+      onClick={handleBatchDelete}
+      type="button"
+    >
+      DELETE
+    </button>
+  </ShThreatPulse>
+  ```
+- Add toast feedback to batch operations — in `handleBatchDelete`, after `fetchPhotos()`:
+  ```jsx
+  showToast(`${ids.length} QUARANTINED`, "info");
+  ```
+- In `handleBatchFavorite`, after `fetchPhotos()`:
+  ```jsx
+  showToast(`${ids.length} TOGGLED`, "info");
+  ```
+
+**Step 3: Build and commit**
+```bash
+cd app/frontend && npm run build
+git add app/frontend/src/pages/Upload.jsx
+git commit -m "feat: superhot-ui uplift for bulk action bar — ShThreatPulse, ShStatusBadge, toast"
 ```
 
 ---
@@ -882,16 +1248,21 @@ Expected: Build succeeds with no errors
 **Step 2: Backend tests**
 
 Run: `cd app && python3 -m pytest ../tests/ -v --timeout=120`
-Expected: All tests pass (including new quarantine test)
+Expected: All tests pass (including new quarantine test + API migration tests)
 
 **Step 3: Verify all new imports resolve**
 
-Run: `cd app/frontend && node -e "require('./node_modules/superhot-ui/preact/ShPageBanner.jsx')" 2>&1 | head -3`
+Run: `cd app/frontend && node -e "import('superhot-ui/preact')" 2>&1 | head -3`
 Expected: No errors
 
-**Step 4: Final commit if any uncommitted changes**
+**Step 4: Verify SPA serves at /**
+
+Run: `cd app && python3 -c "from web_upload import app; c = app.test_client(); r = c.get('/'); assert b'id=\"app\"' in r.data, 'SPA not served at /'; print('OK: SPA at /')"`
+Expected: `OK: SPA at /`
+
+**Step 5: Final commit if any uncommitted changes**
 ```bash
-git add -A
+git add app/ tests/
 git commit -m "chore: final build artifacts + cleanup"
 ```
 
@@ -899,19 +1270,21 @@ git commit -m "chore: final build artifacts + cleanup"
 
 ## Summary
 
-| Batch | Focus | Files | New Components |
-|-------|-------|-------|----------------|
-| 1 | Quarantine endpoint | api.py, tests | — |
-| 2 | Toast + incident + heartbeat infra | lib/toast.js, lib/incident.js, app.jsx | toastManager, heartbeat, recovery |
-| 3 | PhoneLayout (mantra, HUD, toast) | PhoneLayout.jsx | ShMantra, ShIncidentHUD |
-| 4 | ShPageBanner on all 12 views | 12 files | ShPageBanner |
+| Batch | Focus | Files | Key Changes |
+|-------|-------|-------|-------------|
+| 0 | **API consolidation** | api.py, web_upload.py, templates, tests | Move 3 routes, JSON-only upload/delete, SPA at /, delete dead templates |
+| 1 | Quarantine endpoint | api.py, tests | New localhost-only quarantine route |
+| 2 | Toast + incident + heartbeat infra | lib/toast.js, lib/incident.js, app.jsx | Shared state managers, health monitoring |
+| 3 | PhoneLayout (mantra, HUD, toast) | PhoneLayout.jsx | ShMantra, ShIncidentHUD, centralized ShToast |
+| 4 | ShPageBanner on all 12 views | 12 files | Diegetic page headers |
 | 5 | Empty + error states on 5 pages | 5 page files | ShEmptyState, ShErrorState |
-| 6 | Settings full API coverage | Settings.jsx | ShThreatPulse, ShStatusBadge, ShCrtToggle |
+| 6 | Settings system controls | Settings.jsx | Reboot/shutdown ShThreatPulse modals, TV status, MAP, CRT, audio |
 | 7 | Stats page hero cards + chart | Stats.jsx | ShHeroCard, ShTimeChart |
-| 8 | Lightbox albums + duplicates | Lightbox.jsx, Albums.jsx | ShStatusBadge (reuse) |
-| 9 | Search wiring | Upload.jsx, SearchModal.jsx | — |
-| 10 | Atmosphere review | All frontend | — |
-| 11 | Final verification | All | — |
+| 8 | Lightbox albums + duplicates | Lightbox.jsx, Albums.jsx | Album management, duplicate detection |
+| 9 | Search + bulk bar uplift | Upload.jsx, SearchModal.jsx | Search wiring, ShThreatPulse on bulk delete |
+| 10 | Atmosphere review | All frontend | Validation against 11 criteria |
+| 11 | Final verification | All | Build + tests + SPA verification |
 
-**Total: 11 batches, ~20 files, 10 new components, 6 new JS utilities**
+**Total: 12 batches, ~25 files, 10 new superhot-ui components, 6 new JS utilities**
+**API consolidation: web_upload.py drops from 981 → ~500 lines, api.py becomes single source of truth**
 **superhot-ui coverage: 32% → 68% components, 29% → 54% JS modules**


### PR DESCRIPTION
Revises the existing api-ui-superhot plan with three key changes:

1. **Batch 0 (NEW):** API consolidation — move 3 misplaced /api/* routes to api.py, make upload/delete/delete-all JSON-only, serve SPA at /, delete dead legacy templates (index.html, map.html, settings.html)
2. **Batch 6 revised:** Remove Phase 8 overlap (settings import/export, SSH/HTTPS, timezone, frames already done), keep only new additions (reboot/shutdown modals, TV status badge, MAP section, CRT toggle, audio pref)
3. **Batch 9 expanded:** Add superhot-ui treatment for Phase 8 bulk action bar (ShThreatPulse, ShStatusBadge, toast feedback)

Key finding: GET / currently serves the legacy v1 index.html (885 lines of vanilla HTML/JS), not the SPA. The phone Preact SPA is only reachable via /setup entry point. Batch 0 fixes this by serving spa.html at / with catch-all routes for client-side navigation.

**12 batches, ~25 files, 10 new superhot-ui components, 6 JS utilities**
**web_upload.py: 981 → ~500 lines | superhot-ui coverage: 32% → 68%**