### PR TITLE
fix: build-image workflow YAML parse error and missing workflow_call

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -327,16 +327,9 @@ jobs:
           fi
 
           if [ "$RELEASE_STATUS" = "success" ]; then
-            MSG="✅ *FrameCast ${TAG}* released
-
-[GitHub Release](https://github.com/parthalon025/framecast/releases/tag/${TAG})
-
-Image built, QEMU boot tested, cosign signed."
+            printf -v MSG '✅ *FrameCast %s* released\n\n[GitHub Release](https://github.com/parthalon025/framecast/releases/tag/%s)\n\nImage built, QEMU boot tested, cosign signed.' "$TAG" "$TAG"
           else
-            MSG="❌ *FrameCast ${TAG}* release failed
-
-Status: ${RELEASE_STATUS}
-[Check Actions](https://github.com/parthalon025/framecast/actions)"
+            printf -v MSG '❌ *FrameCast %s* release failed\n\nStatus: %s\n[Check Actions](https://github.com/parthalon025/framecast/actions)' "$TAG" "$RELEASE_STATUS"
           fi
 
           curl -sf -X POST \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

Every push triggered a `build-image.yml` failure with `This run likely failed because of a workflow file issue` (0s runtime, 5 consecutive failures).

**Root causes:**

1. **YAML parse error (line 332):** The Telegram notification step used multiline `MSG="..."` assignments inside a `run: |` literal block. Lines like `[GitHub Release](...)` started at column 1, which the YAML parser interpreted as the end of the literal block — a syntax error.

2. **Missing `workflow_call:` trigger:** `build-image.yml` calls `uses: ./.github/workflows/test.yml` as a reusable workflow, but `test.yml` only declared `push:` and `pull_request:` triggers — not `workflow_call:`.

## Fix

- Replace multiline `MSG=` strings with `printf -v MSG` to keep all content on properly indented lines within the YAML block.
- Add `workflow_call:` to `test.yml` triggers so it can be used as a reusable workflow.

## Verification

Both files pass `yaml.safe_load()` — no parse errors.