### PR TITLE
fix: move firewall setup from 02-app to 03-system stage

### DIFF
--- a/pi-gen/stage2-framecast/02-app/01-run-chroot.sh
+++ b/pi-gen/stage2-framecast/02-app/01-run-chroot.sh
@@ -101,9 +101,5 @@ sed -i "s|^MEDIA_DIR=.*|MEDIA_DIR=/home/pi/media|" /opt/framecast/app/.env
 chmod 600 /opt/framecast/app/.env
 chown 1000:1000 /opt/framecast/app/.env
 
-# Firewall: write RFC1918-only rules and enable ufw (C12)
-/usr/local/bin/ufw-setup.sh
-systemctl enable ufw
-
 # Purge pip after install — reduces image size (I35)
 apt-get purge -y python3-pip && apt-get autoremove -y

--- a/pi-gen/stage2-framecast/03-system/01-run-chroot.sh
+++ b/pi-gen/stage2-framecast/03-system/01-run-chroot.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+set -u -o pipefail
+# System hardening steps that run inside the chroot.
+# Runs after 03-system/01-run.sh has installed files into the rootfs.
+
+# Firewall: write RFC1918-only rules and enable ufw (C12)
+/usr/local/bin/ufw-setup.sh
+systemctl enable ufw


### PR DESCRIPTION
## Problem

Pi-gen image build fails with:
```
/bin/bash: line 105: /usr/local/bin/ufw-setup.sh: No such file or directory
```

## Root Cause

Cross-stage dependency bug. `ufw-setup.sh` is installed by `03-system/01-run.sh` (line 26) but called from `02-app/01-run-chroot.sh` (line 105). Pi-gen runs stages numerically — `02-app` completes entirely before `03-system` starts, so the script doesn't exist when the chroot calls it.

## Fix

Move the firewall chroot call (`/usr/local/bin/ufw-setup.sh` + `systemctl enable ufw`) from `02-app/01-run-chroot.sh` to a new `03-system/01-run-chroot.sh`, where the file is actually installed by `03-system/01-run.sh`.